### PR TITLE
SCRUM-27: delete console output from calculate coordinates test class

### DIFF
--- a/src/app/services/calculate-coordinates.service.spec.ts
+++ b/src/app/services/calculate-coordinates.service.spec.ts
@@ -340,12 +340,10 @@ describe('CalculateCoordinatesService', () => {
                 { source: DNode, target: stopNode },
             ],
         };
-        console.log(expectedGraph);
 
         sut.calculateCoordinates(dfg);
 
         sut.graph$.subscribe((graph) => {
-            console.log(graph);
             expect(graph).toEqual(expectedGraph);
         });
     });


### PR DESCRIPTION
Ich denke die Konsolenausgabe im Test habt ihr vergessen zu löschen? Dachte wir korrigieren das vielleicht kurz auch der Story, mit der es in den main gekommen ist.