### PR TITLE
SCRUM-53-CalcualtePetriNetService-funktioniert-nicht

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,6 +15,7 @@
 
     <div class="flexRowAlignSpaceEvenlyStart">
         <button mat-flat-button (click)="openDialog()">Input Event Log</button>
+        <button mat-flat-button (click)="createTestPN()">Create Test PN</button>
     </div>
     <div class="flexRowAlignSpaceEvenlyStart">
         <button mat-flat-button (click)="openHelp()">Hilfe</button>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,9 @@ import { EventLogDialogComponent } from './components/event-log-dialog/event-log
 import { EventLog } from './classes/event-log';
 import { Subscription } from 'rxjs';
 import { ShowFeedbackService } from './services/show-feedback.service';
+import { CalculatePetriNetService } from './services/calculate-petri-net.service';
+import { PetriNet } from './classes/petrinet/petri-net';
+import { DfgBuilder } from './classes/dfg/dfg';
 
 @Component({
     selector: 'app-root',
@@ -14,6 +17,7 @@ export class AppComponent {
     constructor(
         private _matDialog: MatDialog,
         private feedbackService: ShowFeedbackService,
+        private pnCalculationService: CalculatePetriNetService,
     ) {}
 
     public openDialog(): void {
@@ -42,5 +46,27 @@ export class AppComponent {
     `;
 
         this.feedbackService.openHelpDialog(helpMessage);
+    }
+
+    // This method is for test purposes only!
+    // Remove after connection all pieces!
+    public createTestPN(): void {
+        const dfg = new DfgBuilder()
+            .createActivity('A')
+            .createActivity('B')
+            .createActivity('X')
+            .createActivity('Y')
+            .createActivity('Z')
+            .addFromPlayArc('A')
+            .addFromPlayArc('X')
+            .addArc('A', 'B')
+            .addArc('X', 'Y')
+            .addArc('Y', 'Z')
+            .addToStopArc('B')
+            .addToStopArc('Z')
+            .build();
+        const petriNet: PetriNet = new PetriNet(dfg);
+
+        this.pnCalculationService.calculatePetriNet(petriNet);
     }
 }

--- a/src/app/classes/petrinet/petri-net.spec.ts
+++ b/src/app/classes/petrinet/petri-net.spec.ts
@@ -45,7 +45,7 @@ describe('A Petrinet', () => {
         expect(result).toEqual('A');
     });
 
-    it('input place id is "p1" after initialization', () => {
+    it('input place id is "input" after initialization', () => {
         const dfg: Dfg = new DfgBuilder()
             .createActivity('A')
             .addFromPlayArc('A')
@@ -55,10 +55,10 @@ describe('A Petrinet', () => {
         const sut: PetriNet = new PetriNet(dfg);
         const result: string = sut.inputPlace.id;
 
-        expect(result).toEqual('p1');
+        expect(result).toEqual('input');
     });
 
-    it('output place id is "p4" after initialization', () => {
+    it('output place id is "output" after initialization', () => {
         const dfg: Dfg = new DfgBuilder()
             .createActivity('A')
             .addFromPlayArc('A')
@@ -68,7 +68,7 @@ describe('A Petrinet', () => {
         const sut: PetriNet = new PetriNet(dfg);
         const result: string = sut.outputPlace.id;
 
-        expect(result).toEqual('p4');
+        expect(result).toEqual('output');
     });
 
     it('is updated by exclusive cut', () => {
@@ -105,43 +105,45 @@ describe('A Petrinet', () => {
             subDFG2,
         );
 
-        const expectedPlaces: Places = new Places();
+        const expectedPlaces: Places = new Places()
+            .addInputPlace()
+            .addOutputPlace();
         const expectedTransitions: PetriNetTransitions =
             new PetriNetTransitions()
                 .createTransition('play')
                 .createTransition('stop');
         const expectedArcs: PetriNetArcs = new PetriNetArcs()
             .addPlaceToTransitionArc(
-                expectedPlaces.addPlace().getPlaceByID('p1'),
+                expectedPlaces.input,
                 expectedTransitions.getTransitionByID('t1'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t1'),
-                expectedPlaces.addPlace().getPlaceByID('p2'),
+                expectedPlaces.addPlace().getPlaceByID('p1'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p2'),
+                expectedPlaces.getPlaceByID('p1'),
                 expectedTransitions.addDFG(subDFG1).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getLastTransition(),
-                expectedPlaces.addPlace().getPlaceByID('p3'),
+                expectedPlaces.addPlace().getPlaceByID('p2'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p3'),
+                expectedPlaces.getPlaceByID('p2'),
                 expectedTransitions.getTransitionByID('t2'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t2'),
-                expectedPlaces.addPlace().getPlaceByID('p4'),
+                expectedPlaces.output,
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p2'),
+                expectedPlaces.getPlaceByID('p1'),
                 expectedTransitions.addDFG(subDFG2).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getLastTransition(),
-                expectedPlaces.getPlaceByID('p3'),
+                expectedPlaces.getPlaceByID('p2'),
             );
 
         expect(sut.places).toEqual(expectedPlaces);
@@ -182,45 +184,47 @@ describe('A Petrinet', () => {
             subDFG2,
         );
 
-        const expectedPlaces: Places = new Places();
+        const expectedPlaces: Places = new Places()
+            .addInputPlace()
+            .addOutputPlace();
         const expectedTransitions: PetriNetTransitions =
             new PetriNetTransitions()
                 .createTransition('play')
                 .createTransition('stop');
         const expectedArcs: PetriNetArcs = new PetriNetArcs()
             .addPlaceToTransitionArc(
-                expectedPlaces.addPlace().getPlaceByID('p1'),
+                expectedPlaces.input,
                 expectedTransitions.getTransitionByID('t1'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t1'),
-                expectedPlaces.addPlace().getPlaceByID('p2'),
+                expectedPlaces.addPlace().getPlaceByID('p1'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p2'),
+                expectedPlaces.getPlaceByID('p1'),
                 expectedTransitions.addDFG(subDFG1).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.addDFG(subDFG2).getLastTransition(),
-                expectedPlaces.addPlace().getPlaceByID('p3'),
+                expectedPlaces.addPlace().getPlaceByID('p2'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p3'),
+                expectedPlaces.getPlaceByID('p2'),
                 expectedTransitions.getTransitionByID('t2'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t2'),
-                expectedPlaces.addPlace().getPlaceByID('p4'),
+                expectedPlaces.output,
             );
         expectedArcs
             .addTransitionToPlaceArc(
                 expectedArcs.getNextTransition(
-                    expectedPlaces.getPlaceByID('p2'),
+                    expectedPlaces.getPlaceByID('p1'),
                 ),
-                expectedPlaces.addPlace().getPlaceByID('p5'),
+                expectedPlaces.addPlace().getPlaceByID('p3'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p5'),
+                expectedPlaces.getPlaceByID('p3'),
                 expectedTransitions.getLastTransition(),
             );
 
@@ -271,51 +275,53 @@ describe('A Petrinet', () => {
             subDFG2,
         );
 
-        const expectedPlaces: Places = new Places();
+        const expectedPlaces: Places = new Places()
+            .addInputPlace()
+            .addOutputPlace();
         const expectedTransitions: PetriNetTransitions =
             new PetriNetTransitions()
                 .createTransition('play')
                 .createTransition('stop');
         const expectedArcs: PetriNetArcs = new PetriNetArcs()
             .addPlaceToTransitionArc(
-                expectedPlaces.addPlace().getPlaceByID('p1'),
+                expectedPlaces.input,
                 expectedTransitions.getTransitionByID('t1'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t1'),
-                expectedPlaces.addPlace().getPlaceByID('p2'),
+                expectedPlaces.addPlace().getPlaceByID('p1'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p2'),
+                expectedPlaces.getPlaceByID('p1'),
                 expectedTransitions.addDFG(subDFG1).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getLastTransition(),
-                expectedPlaces.addPlace().getPlaceByID('p3'),
+                expectedPlaces.addPlace().getPlaceByID('p2'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p3'),
+                expectedPlaces.getPlaceByID('p2'),
                 expectedTransitions.getTransitionByID('t2'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t2'),
-                expectedPlaces.addPlace().getPlaceByID('p4'),
+                expectedPlaces.output,
             );
         expectedArcs
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t1'),
-                expectedPlaces.addPlace().getPlaceByID('p5'),
+                expectedPlaces.addPlace().getPlaceByID('p3'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p5'),
+                expectedPlaces.getPlaceByID('p3'),
                 expectedTransitions.addDFG(subDFG2).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getLastTransition(),
-                expectedPlaces.addPlace().getPlaceByID('p6'),
+                expectedPlaces.addPlace().getPlaceByID('p4'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p6'),
+                expectedPlaces.getPlaceByID('p4'),
                 expectedTransitions.getTransitionByID('t2'),
             );
 
@@ -354,43 +360,47 @@ describe('A Petrinet', () => {
             subDFG2,
         );
 
-        const expectedPlaces: Places = new Places();
+        const expectedPlaces: Places = new Places()
+            .addInputPlace()
+            .addOutputPlace();
+
         const expectedTransitions: PetriNetTransitions =
             new PetriNetTransitions()
                 .createTransition('play')
                 .createTransition('stop');
+
         const expectedArcs: PetriNetArcs = new PetriNetArcs()
             .addPlaceToTransitionArc(
-                expectedPlaces.addPlace().getPlaceByID('p1'),
+                expectedPlaces.input,
                 expectedTransitions.getTransitionByID('t1'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t1'),
-                expectedPlaces.addPlace().getPlaceByID('p2'),
+                expectedPlaces.addPlace().getPlaceByID('p1'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p2'),
+                expectedPlaces.getPlaceByID('p1'),
                 expectedTransitions.addDFG(subDFG1).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getLastTransition(),
-                expectedPlaces.addPlace().getPlaceByID('p3'),
+                expectedPlaces.addPlace().getPlaceByID('p2'),
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p3'),
+                expectedPlaces.getPlaceByID('p2'),
                 expectedTransitions.getTransitionByID('t2'),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getTransitionByID('t2'),
-                expectedPlaces.addPlace().getPlaceByID('p4'),
+                expectedPlaces.output,
             )
             .addPlaceToTransitionArc(
-                expectedPlaces.getPlaceByID('p3'),
+                expectedPlaces.getPlaceByID('p2'),
                 expectedTransitions.addDFG(subDFG2).getLastTransition(),
             )
             .addTransitionToPlaceArc(
                 expectedTransitions.getLastTransition(),
-                expectedPlaces.getPlaceByID('p2'),
+                expectedPlaces.getPlaceByID('p1'),
             );
 
         expect(sut.places).toEqual(expectedPlaces);

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -17,10 +17,12 @@ export class PetriNet {
     }
 
     private initializeOriginDFG(dfg: Dfg): PetriNet {
+        this._places.addInputPlace().addOutputPlace();
         this._transitions.createTransition('play').createTransition('stop');
+
         this._arcs
             .addPlaceToTransitionArc(
-                this._places.addPlace().getLastPlace(),
+                this._places.input,
                 this._transitions.getTransitionByID('t1'),
             )
             .addTransitionToPlaceArc(
@@ -41,8 +43,9 @@ export class PetriNet {
             )
             .addTransitionToPlaceArc(
                 this._transitions.getTransitionByID('t2'),
-                this._places.addPlace().getLastPlace(),
+                this._places.output,
             );
+
         return this;
     }
 

--- a/src/app/classes/petrinet/places.ts
+++ b/src/app/classes/petrinet/places.ts
@@ -46,6 +46,6 @@ export class Places {
     }
 
     get output(): Place {
-        return this._places[3];
+        return this._places[1];
     }
 }

--- a/src/app/services/calculate-petri-net.service.ts
+++ b/src/app/services/calculate-petri-net.service.ts
@@ -185,7 +185,7 @@ export class CalculatePetriNetService {
         let yCoordinate: number = 100;
         let xOfLastModeledNode: number = 100;
 
-        const inputPlace: Place = petriNet.places.getPlaceByID('input');
+        const inputPlace: Place = petriNet.places.input;
         nodes.push(new PlaceNode('input', 100, 100));
 
         const neighbours: Array<PetriNetTransition> =


### PR DESCRIPTION
- Use input getter on PetriNet
- Update initialization of PetriNet
- Refactor tests to new 'input' and 'output' place behavior
- Add test button to insert dummy pn