### PR TITLE
SCRUM-19-Ende-anzeigen

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,9 +7,6 @@ import { CalculateDfgService } from './services/calculate-dfg.service';
 import { Dfg } from './classes/dfg/dfg';
 import { PetriNetManagementService } from './services/petri-net-management.service';
 import { ShowFeedbackService } from './services/show-feedback.service';
-import { CalculatePetriNetService } from './services/calculate-petri-net.service';
-import { PetriNet } from './classes/petrinet/petri-net';
-import { DfgBuilder } from './classes/dfg/dfg';
 
 @Component({
     selector: 'app-root',
@@ -22,7 +19,6 @@ export class AppComponent {
         private _calculateDfgService: CalculateDfgService,
         private _petriNetManagementService: PetriNetManagementService,
         private feedbackService: ShowFeedbackService,
-        private pnCalculationService: CalculatePetriNetService,
     ) {}
 
     public openDialog(): void {
@@ -58,5 +54,9 @@ export class AppComponent {
     `;
 
         this.feedbackService.openHelpDialog(helpMessage);
+    }
+
+    get actionButtonsAreDisabled(): boolean {
+        return !this._petriNetManagementService.isModifiable;
     }
 }

--- a/src/app/classes/petrinet/petri-net-transitions.ts
+++ b/src/app/classes/petrinet/petri-net-transitions.ts
@@ -42,7 +42,7 @@ export class PetriNetTransitions {
     }
 
     eachTransitionIsBaseCase(): boolean {
-        for (const transition of this.transitions) {
+        for (const transition of this._transitions) {
             if (transition instanceof Dfg) {
                 return false;
             }

--- a/src/app/classes/petrinet/petri-net-transitions.ts
+++ b/src/app/classes/petrinet/petri-net-transitions.ts
@@ -41,6 +41,15 @@ export class PetriNetTransitions {
         return this;
     }
 
+    eachTransitionIsBaseCase(): boolean {
+        for (const transition of this.transitions) {
+            if (transition instanceof Dfg) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     getLastTransition(): PetriNetTransition {
         return this._transitions[this._transitions.length - 1];
     }

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -151,6 +151,10 @@ export class PetriNet {
         return replacingTransition;
     }
 
+    isBasicPetriNet(): boolean {
+        return this.transitions.eachTransitionIsBaseCase();
+    }
+
     get inputPlace(): Place {
         return this._places.input;
     }

--- a/src/app/components/cut-execution/cut-execution.component.css
+++ b/src/app/components/cut-execution/cut-execution.component.css
@@ -1,0 +1,5 @@
+/* CSS-Klasse für den deaktivierten Zustand */
+.disabled-component {
+    pointer-events: none;
+    opacity: 0.5;
+}

--- a/src/app/components/cut-execution/cut-execution.component.html
+++ b/src/app/components/cut-execution/cut-execution.component.html
@@ -1,13 +1,18 @@
 <h3>1. Kanten wählen -> 2. Cut wählen -> 3. Cut durchführen!</h3>
-<form [formGroup]="radioForm">
-    <mat-radio-group formControlName="selectedCut">
-        <mat-radio-button *ngFor="let option of radioOptions" [value]="option">
-            {{ option }}
-        </mat-radio-button>
-    </mat-radio-group>
-</form>
-<button mat-raised-button="primary" (click)="onCutClick()">
-    Cut durchfuehren
-</button>
-<!-- Abstand einfuegen? Wie? -->
-<button mat-stroked-button (click)="onCancelClick()">Cancel</button>
+<div [ngClass]="{ 'disabled-component': actionButtonsAreDisabled }">
+    <form [formGroup]="radioForm">
+        <mat-radio-group formControlName="selectedCut">
+            <mat-radio-button
+                *ngFor="let option of radioOptions"
+                [value]="option"
+            >
+                {{ option }}
+            </mat-radio-button>
+        </mat-radio-group>
+    </form>
+    <button mat-raised-button="primary" (click)="onCutClick()">
+        Cut durchfuehren
+    </button>
+    <!-- Abstand einfuegen? Wie? -->
+    <button mat-stroked-button (click)="onCancelClick()">Cancel</button>
+</div>

--- a/src/app/components/cut-execution/cut-execution.component.ts
+++ b/src/app/components/cut-execution/cut-execution.component.ts
@@ -10,6 +10,7 @@ import { Activities } from 'src/app/classes/dfg/activities';
 import { Arcs } from 'src/app/classes/dfg/arcs';
 import { EventLog } from 'src/app/classes/event-log';
 import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
+import { PetriNetManagementService } from 'src/app/services/petri-net-management.service';
 
 export enum CutType {
     ExclusiveCut = 'ExclusiveCut',
@@ -43,12 +44,13 @@ export class CutExecutionComponent implements OnInit {
     arcsSelectedDummy: Arcs = new Arcs();
 
     constructor(
-        private fb: FormBuilder,
-        private executeCutService: ExecuteCutService,
-        private feedbackService: ShowFeedbackService,
+        private _fb: FormBuilder,
+        private _executeCutService: ExecuteCutService,
+        private _feedbackService: ShowFeedbackService,
+        private _petriNetManagementService: PetriNetManagementService,
         // private kantenSammelService: KantenSammelService
     ) {
-        this.radioForm = this.fb.group({
+        this.radioForm = this._fb.group({
             selectedCut: null,
         });
     }
@@ -60,14 +62,14 @@ export class CutExecutionComponent implements OnInit {
     onCutClick(): void {
         const selectedValue = this.radioForm.get('selectedCut')?.value;
         if (selectedValue) {
-            this.executeCutService.execute(
+            this._executeCutService.execute(
                 this.dfgDummy,
                 this.arcsSelectedDummy,
                 selectedValue,
             );
             this.resetRadioSelection();
         } else {
-            this.feedbackService.showMessage(
+            this._feedbackService.showMessage(
                 'Es wurde kein Cut ausgewählt!',
                 true,
                 'Sie müssen einen Cut über die Radio-Buttons auswählen, um einen Cut durchführen zu können.',
@@ -78,11 +80,15 @@ export class CutExecutionComponent implements OnInit {
     onCancelClick(): void {
         if (this.radioForm.get('selectedCut')?.value !== null) {
             this.resetRadioSelection();
-            this.feedbackService.showMessage('Cutauswahl abgebrochen.', false);
+            this._feedbackService.showMessage('Cutauswahl abgebrochen.', false);
         }
     }
 
     resetRadioSelection(): void {
         this.radioForm.get('selectedCut')?.setValue(null);
+    }
+
+    get actionButtonsAreDisabled(): boolean {
+        return !this._petriNetManagementService.isModifiable;
     }
 }

--- a/src/app/services/execute-cut.service.spec.ts
+++ b/src/app/services/execute-cut.service.spec.ts
@@ -22,7 +22,7 @@ describe('ExecuteCutService', () => {
     );
 
     beforeEach(() => {
-        pnManagementServiceSpy = new PetriNetManagementService();
+        pnManagementServiceSpy = new PetriNetManagementService(showFeedbackServiceMockInstance);
         calculateDfgService = new CalculateDfgService();
         sut = new ExecuteCutService(
             pnManagementServiceSpy,

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { PetriNet } from '../classes/petrinet/petri-net';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Dfg } from '../classes/dfg/dfg';
+import { ShowFeedbackService } from './show-feedback.service';
 
 @Injectable({
     providedIn: 'root',
@@ -16,11 +17,17 @@ export class PetriNetManagementService {
         return this._petriNet$.asObservable();
     }
 
-    constructor() {}
+    constructor(private _showFeedbackService: ShowFeedbackService) {}
 
     public initialize(dfg: Dfg): void {
         this._petriNet = new PetriNet(dfg);
         this._petriNet$.next(this._petriNet);
+        if (this._petriNet.isBasicPetriNet()) {
+            this._showFeedbackService.showMessage(
+                'There is nothing to split on this event log.',
+                false,
+            );
+        }
     }
 
     public updatePnByExclusiveCut(
@@ -57,5 +64,11 @@ export class PetriNetManagementService {
 
     private updatePn(): void {
         this._petriNet$.next(this._petriNet);
+        if (this._petriNet.isBasicPetriNet()) {
+            this._showFeedbackService.showMessage(
+                'The input event log is completely splitted.',
+                false,
+            );
+        }
     }
 }

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -9,6 +9,7 @@ import { ShowFeedbackService } from './show-feedback.service';
 })
 export class PetriNetManagementService {
     private _petriNet: PetriNet = new PetriNet();
+    private _isModifiable: boolean = false;
 
     private _petriNet$: BehaviorSubject<PetriNet> =
         new BehaviorSubject<PetriNet>(this._petriNet);
@@ -17,17 +18,24 @@ export class PetriNetManagementService {
         return this._petriNet$.asObservable();
     }
 
+    get isModifiable(): boolean {
+        return this._isModifiable;
+    }
+
     constructor(private _showFeedbackService: ShowFeedbackService) {}
 
     public initialize(dfg: Dfg): void {
         this._petriNet = new PetriNet(dfg);
-        this._petriNet$.next(this._petriNet);
         if (this._petriNet.isBasicPetriNet()) {
+            this._isModifiable = false;
             this._showFeedbackService.showMessage(
                 'There is nothing to split on this event log.',
                 false,
             );
+        } else {
+            this._isModifiable = true;
         }
+        this._petriNet$.next(this._petriNet);
     }
 
     public updatePnByExclusiveCut(
@@ -63,12 +71,15 @@ export class PetriNetManagementService {
     }
 
     private updatePn(): void {
-        this._petriNet$.next(this._petriNet);
         if (this._petriNet.isBasicPetriNet()) {
+            this._isModifiable = false;
             this._showFeedbackService.showMessage(
                 'The input event log is completely splitted.',
                 false,
             );
+        } else {
+            this._isModifiable = true;
         }
+        this._petriNet$.next(this._petriNet);
     }
 }


### PR DESCRIPTION
-Sobald ein PN bzw. Event Log komplett zerlegt ist, wird ein Snackbar-Feedback ausgegeben, dass es nichts weiter zu tun gibt
-Falls ein eigegebenes Event Log bereits minimal ist, wird auch ein feedback audgegeben, dass nichts zu tun ist.
-In PN-Management-Service exisitiert eine property inkl. getter, über die der Zustand des PN abgerufen werden kann. Damit können die Buttons und Komponenten nach Bedarf deaktiviert und aktiviert werden.