### PR TITLE
Scrum 23 input format innerhalb input dialog vor absenden ueberpruefen

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { EventLogDialogComponent } from './components/event-log-dialog/event-log-dialog.component';
 import { EventLog } from './classes/event-log';
-import { Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { CalculateDfgService } from './services/calculate-dfg.service';
 import { Dfg } from './classes/dfg/dfg';
 import { PetriNetManagementService } from './services/petri-net-management.service';
@@ -17,6 +17,8 @@ import { DfgBuilder } from './classes/dfg/dfg';
     styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
+    petriNet: PetriNet = new PetriNet();
+
     constructor(
         private _matDialog: MatDialog,
         private _calculateDfgService: CalculateDfgService,
@@ -41,6 +43,15 @@ export class AppComponent {
 
                 const dfg: Dfg = this._calculateDfgService.calculate(eventLog);
                 this._petriNetManagementService.initialize(dfg);
+
+                // this._petriNetManagementService.petriNet$.subscribe((net) => {
+                //     this.petriNet = net;
+                // });
+                // const petriNet: BehaviorSubject<PetriNet>;
+                // petriNet = this._petriNetManagementService.petriNet$;
+
+                // this.pnCalculationService.calculatePetriNet(this.petriNet);
+                // console.log(this.petriNet);
             },
             complete: () => sub.unsubscribe(),
         });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,14 +44,14 @@ export class AppComponent {
                 const dfg: Dfg = this._calculateDfgService.calculate(eventLog);
                 this._petriNetManagementService.initialize(dfg);
 
-                // this._petriNetManagementService.petriNet$.subscribe((net) => {
-                //     this.petriNet = net;
-                // });
+                this._petriNetManagementService.petriNet$.subscribe((net) => {
+                    this.petriNet = net;
+                });
                 // const petriNet: BehaviorSubject<PetriNet>;
                 // petriNet = this._petriNetManagementService.petriNet$;
 
-                // this.pnCalculationService.calculatePetriNet(this.petriNet);
-                // console.log(this.petriNet);
+                this.pnCalculationService.calculatePetriNet(this.petriNet);
+                console.log(this.petriNet);
             },
             complete: () => sub.unsubscribe(),
         });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,14 +2,13 @@ import { Component } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { EventLogDialogComponent } from './components/event-log-dialog/event-log-dialog.component';
 import { EventLog } from './classes/event-log';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { CalculateDfgService } from './services/calculate-dfg.service';
 import { Dfg } from './classes/dfg/dfg';
 import { PetriNetManagementService } from './services/petri-net-management.service';
 import { ShowFeedbackService } from './services/show-feedback.service';
 import { CalculatePetriNetService } from './services/calculate-petri-net.service';
 import { PetriNet } from './classes/petrinet/petri-net';
-import { DfgBuilder } from './classes/dfg/dfg';
 
 @Component({
     selector: 'app-root',
@@ -17,14 +16,11 @@ import { DfgBuilder } from './classes/dfg/dfg';
     styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
-    petriNet: PetriNet = new PetriNet();
-
     constructor(
         private _matDialog: MatDialog,
         private _calculateDfgService: CalculateDfgService,
         private _petriNetManagementService: PetriNetManagementService,
         private feedbackService: ShowFeedbackService,
-        private pnCalculationService: CalculatePetriNetService,
     ) {}
 
     public openDialog(): void {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import {
 import { DrawingAreaModule } from './components/drawing-area/drawing-area.module';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
+import { TextFieldModule } from '@angular/cdk/text-field';
 
 @NgModule({
     declarations: [AppComponent, FooterComponent],
@@ -33,6 +34,7 @@ import { MatDialogModule } from '@angular/material/dialog';
         MatSnackBarModule,
         FormsModule,
         MatDialogModule,
+        TextFieldModule,
     ],
     providers: [
         {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,28 +18,28 @@ import { DrawingAreaModule } from './components/drawing-area/drawing-area.module
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { CutExecutionComponent } from './components/cut-execution/cut-execution.component';
-import { ExampleEventLogsComponent } from "./components/example-event-logs/example-event-logs.component";
+import { ExampleEventLogsComponent } from './components/example-event-logs/example-event-logs.component';
 import { TextFieldModule } from '@angular/cdk/text-field';
 
 @NgModule({
     declarations: [AppComponent, FooterComponent],
     bootstrap: [AppComponent],
     imports: [
-    BrowserModule,
-    BrowserAnimationsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
-    MatIconModule,
-    ReactiveFormsModule,
-    DrawingAreaModule,
-    MatSnackBarModule,
-    FormsModule,
-    MatDialogModule,
-    CutExecutionComponent,
-    ExampleEventLogsComponent
+        BrowserModule,
+        BrowserAnimationsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
+        MatIconModule,
+        ReactiveFormsModule,
+        DrawingAreaModule,
+        MatSnackBarModule,
+        FormsModule,
+        MatDialogModule,
+        CutExecutionComponent,
+        ExampleEventLogsComponent,
         TextFieldModule,
-],
+    ],
     providers: [
         {
             provide: APP_BASE_HREF,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { CutExecutionComponent } from './components/cut-execution/cut-execution.component';
 import { ExampleEventLogsComponent } from './components/example-event-logs/example-event-logs.component';
 import { TextFieldModule } from '@angular/cdk/text-field';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
     declarations: [AppComponent, FooterComponent],
@@ -39,6 +40,7 @@ import { TextFieldModule } from '@angular/cdk/text-field';
         CutExecutionComponent,
         ExampleEventLogsComponent,
         TextFieldModule,
+        MatTooltipModule,
     ],
     providers: [
         {

--- a/src/app/components/event-log-dialog/event-log-dialog.component.html
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.html
@@ -1,8 +1,8 @@
-<h2 mat-dialog-title>Event-Log-Eingabe</h2>
+<h2 mat-dialog-title>Event-Log Input</h2>
 <mat-dialog-content class="mat-typography">
     <form (ngSubmit)="onOkClick()">
         <mat-form-field style="width: 100%">
-            <mat-label>Bitte hier EventLog eingeben.</mat-label>
+            <mat-label>Enter Event-Log here!</mat-label>
             <input
                 matInput
                 cdkTextareaAutosize
@@ -17,7 +17,7 @@
                     eventLogControl.dirty
                 "
             >
-                keine leere Eingabe möglich
+                There ist no empty input allowed!
             </mat-error>
             <mat-error
                 *ngIf="
@@ -25,14 +25,13 @@
                     eventLogControl.dirty
                 "
             >
-                Ungültige Eingabe. Ursache: Ein führendes Plus zu Beginn oder zu
-                viele Leerzeichen hintereinander oder zu viele Pluszeichen
+                Invalid Input Reason: A leading plus at the beginning, too many
+                whitespaces in a row or too many plus signs
             </mat-error>
             <mat-hint
-                >Aktivitäten pro Trace verkettet durch genau ein Leerzeichen
-                eingeben. Die Traces durch ein Plus (+) verkettet eingeben. Die
-                Leerzeichen vor und nach dem Plus sind optional. Es ist keine
-                leere Eingabe möglich.
+                >Activities per trace concatenated by exactly one whitespace.
+                The traces concatenated by a plus (+). The whitespaces before
+                and after the plus are optional. No empty input is allowed.
             </mat-hint>
         </mat-form-field>
         <mat-dialog-actions align="end">

--- a/src/app/components/event-log-dialog/event-log-dialog.component.html
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.html
@@ -1,16 +1,16 @@
 <h2 mat-dialog-title>Event-Log-Eingabe</h2>
 <mat-dialog-content class="mat-typography">
-    <form>
+    <form (ngSubmit)="onOkClick()">
         <mat-form-field style="width: 100%">
             <mat-label>Bitte hier EventLog eingeben.</mat-label>
-            <textarea
+            <input
                 matInput
                 cdkTextareaAutosize
                 cdkAutosizeMinRows="4"
-                placeholder="A B C + D
-                ..."
+                placeholder="A B C + D+F + Y Z ..."
                 [formControl]="eventLogControl"
-            ></textarea>
+                cdkFocusInitial
+            />
             <mat-error
                 *ngIf="
                     eventLogControl.hasError('required') &&
@@ -25,23 +25,26 @@
                     eventLogControl.dirty
                 "
             >
-                Ungültige Eingabe. > A B C + C + A Z ...
+                Ungültige Eingabe. Ursache: Ein führendes Plus zu Beginn oder zu
+                viele Leerzeichen hintereinander oder zu viele Pluszeichen
             </mat-error>
             <mat-hint
-                >Aktivitäten pro Trace verkettet durch ein Leerzeichen eingeben.
-                Die Traces durch ein Plus (+) verkettet eingeben.
+                >Aktivitäten pro Trace verkettet durch genau ein Leerzeichen
+                eingeben. Die Traces durch ein Plus (+) verkettet eingeben. Die
+                Leerzeichen vor und nach dem Plus sind optional. Es ist keine
+                leere Eingabe möglich.
             </mat-hint>
         </mat-form-field>
+        <mat-dialog-actions align="end">
+            <button mat-button mat-dialog-close>Cancel</button>
+            <button
+                mat-button
+                type="submit"
+                cdkFocusInitial
+                [disabled]="eventLogControl.invalid"
+            >
+                Ok
+            </button>
+        </mat-dialog-actions>
     </form>
 </mat-dialog-content>
-<mat-dialog-actions align="end">
-    <button mat-button mat-dialog-close>Cancel</button>
-    <button
-        mat-button
-        (click)="onOkClick()"
-        cdkFocusInitial
-        [disabled]="eventLogControl.invalid"
-    >
-        Ok
-    </button>
-</mat-dialog-actions>

--- a/src/app/components/event-log-dialog/event-log-dialog.component.html
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.html
@@ -7,7 +7,7 @@
                 matInput
                 cdkTextareaAutosize
                 cdkAutosizeMinRows="4"
-                placeholder="A+B+C 
+                placeholder="A B C + D
                 ..."
                 [formControl]="eventLogControl"
             ></textarea>
@@ -25,11 +25,11 @@
                     eventLogControl.dirty
                 "
             >
-                Ungültige Eingabe. > A+B+C C+A+Z ...
+                Ungültige Eingabe. > A B C + C + A Z ...
             </mat-error>
             <mat-hint
-                >Aktivitäten pro Trace verkettet durch ein Plus (+) eingeben.
-                Ein Trace pro Zeile. (A+B+C C ...)
+                >Aktivitäten pro Trace verkettet durch ein Leerzeichen eingeben.
+                Die Traces durch ein Plus (+) verkettet eingeben.
             </mat-hint>
         </mat-form-field>
     </form>

--- a/src/app/components/event-log-dialog/event-log-dialog.component.html
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.html
@@ -1,20 +1,47 @@
-<h2 mat-dialog-title>Input Event Log</h2>
+<h2 mat-dialog-title>Event-Log-Eingabe</h2>
 <mat-dialog-content class="mat-typography">
     <form>
         <mat-form-field style="width: 100%">
-            <mat-label>Enter a sequence...</mat-label>
+            <mat-label>Bitte hier EventLog eingeben.</mat-label>
             <textarea
                 matInput
-                placeholder="Ex. It makes me feel..."
-                [(ngModel)]="eventLogInput"
-                [ngModelOptions]="{ standalone: true }"
+                cdkTextareaAutosize
+                cdkAutosizeMinRows="4"
+                placeholder="A+B+C 
+                ..."
+                [formControl]="eventLogControl"
             ></textarea>
+            <mat-error
+                *ngIf="
+                    eventLogControl.hasError('required') &&
+                    eventLogControl.dirty
+                "
+            >
+                keine leere Eingabe möglich
+            </mat-error>
+            <mat-error
+                *ngIf="
+                    eventLogControl.hasError('invalidInput') &&
+                    eventLogControl.dirty
+                "
+            >
+                Ungültige Eingabe. > A+B+C C+A+Z ...
+            </mat-error>
+            <mat-hint
+                >Aktivitäten pro Trace verkettet durch ein Plus (+) eingeben.
+                Ein Trace pro Zeile. (A+B+C C ...)
+            </mat-hint>
         </mat-form-field>
     </form>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
     <button mat-button mat-dialog-close>Cancel</button>
-    <button mat-button (click)="onOkClick()" cdkFocusInitial>
+    <button
+        mat-button
+        (click)="onOkClick()"
+        cdkFocusInitial
+        [disabled]="eventLogControl.invalid"
+    >
         Ok
     </button>
 </mat-dialog-actions>

--- a/src/app/components/event-log-dialog/event-log-dialog.component.html
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.html
@@ -1,23 +1,30 @@
 <h2 mat-dialog-title>Event-Log Input</h2>
 <mat-dialog-content class="mat-typography">
     <form (ngSubmit)="onOkClick()">
-        <mat-form-field style="width: 100%">
+        <mat-form-field
+            style="width: 100%"
+            hintLabel="Activities per trace concatenated by exactly one whitespace.
+                The traces concatenated by a plus (+). The whitespaces before
+                and after the plus are optional. No empty input is allowed."
+        >
             <mat-label>Enter Event-Log here!</mat-label>
-            <input
+            <textarea
                 matInput
                 cdkTextareaAutosize
                 cdkAutosizeMinRows="4"
                 placeholder="A B C + D+F + Y Z ..."
                 [formControl]="eventLogControl"
                 cdkFocusInitial
-            />
+                (keydown)="onKeyDown($event)"
+                #textarea
+            ></textarea>
             <mat-error
                 *ngIf="
                     eventLogControl.hasError('required') &&
                     eventLogControl.dirty
                 "
             >
-                There ist no empty input allowed!
+                There is no empty input allowed!
             </mat-error>
             <mat-error
                 *ngIf="
@@ -28,19 +35,34 @@
                 Invalid Input Reason: A leading plus at the beginning, too many
                 whitespaces in a row or too many plus signs
             </mat-error>
-            <mat-hint
-                >Activities per trace concatenated by exactly one whitespace.
-                The traces concatenated by a plus (+). The whitespaces before
-                and after the plus are optional. No empty input is allowed.
-            </mat-hint>
         </mat-form-field>
         <mat-dialog-actions align="end">
-            <button mat-button mat-dialog-close>Cancel</button>
             <button
-                mat-button
+                mat-fab
+                extended
+                mat-dialog-close
+                color=""
+                matTooltip="Close Dialog"
+            >
+                Cancel
+            </button>
+            <button
+                mat-fab
+                extended
+                matTooltip="Clear the text input"
+                [disabled]="eventLogControl.value === ''"
+                (click)="clearTextarea(textarea)"
+                color="accent"
+            >
+                Clear
+            </button>
+            <button
+                mat-fab
+                extended
+                matTooltip="You can also press Ctrl + Enter to submit."
                 type="submit"
-                cdkFocusInitial
                 [disabled]="eventLogControl.invalid"
+                color="primary"
             >
                 Ok
             </button>

--- a/src/app/components/event-log-dialog/event-log-dialog.component.ts
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.ts
@@ -13,9 +13,6 @@ import { EventLog } from 'src/app/classes/event-log';
 import { EventLogParserService } from 'src/app/services/event-log-parser.service';
 import { CommonModule } from '@angular/common';
 import { EventLogValidationService } from 'src/app/services/event-log-validation.service';
-import { CalculateCoordinatesService } from 'src/app/services/calculate-coordinates.service';
-import { CalculateDfgService } from 'src/app/services/calculate-dfg.service';
-import { Dfg } from 'src/app/classes/dfg/dfg';
 
 @Component({
     selector: 'app-event-log-dialog',
@@ -44,8 +41,6 @@ export class EventLogDialogComponent implements OnInit {
     constructor(
         private dialogRef: MatDialogRef<EventLogDialogComponent, EventLog>,
         private eventLogParserService: EventLogParserService,
-        private calculateDfgService: CalculateDfgService,
-        private calculateCoordinatesService: CalculateCoordinatesService,
         private eventLogValidationService: EventLogValidationService,
     ) {}
 
@@ -72,10 +67,7 @@ export class EventLogDialogComponent implements OnInit {
         const eventLog: EventLog = this.eventLogParserService.parse(
             this.eventLogControl.value!,
         );
-        const dfg: Dfg = this.calculateDfgService.calculate(eventLog);
-        const graph =
-            this.calculateCoordinatesService.calculateCoordinates(dfg);
-        console.log(graph);
+
         this.dialogRef.close(eventLog);
     }
 }

--- a/src/app/components/event-log-dialog/event-log-dialog.component.ts
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.ts
@@ -6,6 +6,7 @@ import {
     Validators,
 } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -25,6 +26,7 @@ import { EventLogValidationService } from 'src/app/services/event-log-validation
         MatInputModule,
         ReactiveFormsModule,
         CommonModule,
+        MatTooltipModule,
     ],
     templateUrl: './event-log-dialog.component.html',
     styleUrl: './event-log-dialog.component.css',
@@ -69,5 +71,33 @@ export class EventLogDialogComponent implements OnInit {
         );
 
         this.dialogRef.close(eventLog);
+    }
+
+    onKeyDown(event: KeyboardEvent): void {
+        if (event.ctrlKey && event.key === 'Enter') {
+            event.preventDefault();
+            if (this.eventLogControl.valid) {
+                this.onOkClick();
+            }
+        } else if (event.key === 'Enter') {
+            event.preventDefault();
+            const textarea = event.target as HTMLTextAreaElement;
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+
+            const value = textarea.value;
+            textarea.value =
+                value.substring(0, start) + '\n' + value.substring(end);
+
+            textarea.selectionStart = textarea.selectionEnd = start + 1;
+        }
+    }
+
+    clearTextarea(textarea: HTMLTextAreaElement): void {
+        this.eventLogControl.setValue('');
+        this.eventLogControl.markAsTouched();
+        this.eventLogControl.updateValueAndValidity();
+
+        textarea.focus();
     }
 }

--- a/src/app/components/event-log-dialog/event-log-dialog.component.ts
+++ b/src/app/components/event-log-dialog/event-log-dialog.component.ts
@@ -1,5 +1,10 @@
-import { Component, inject } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Component, OnInit } from '@angular/core';
+import {
+    FormControl,
+    FormsModule,
+    ReactiveFormsModule,
+    Validators,
+} from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -10,6 +15,8 @@ import { EventLog } from 'src/app/classes/event-log';
 import { CalculateCoordinatesService } from 'src/app/services/calculate-coordinates.service';
 import { CalculateDfgService } from 'src/app/services/calculate-dfg.service';
 import { EventLogParserService } from 'src/app/services/event-log-parser.service';
+import { CommonModule } from '@angular/common';
+import { EventLogValidationService } from 'src/app/services/event-log-validation.service';
 
 @Component({
     selector: 'app-event-log-dialog',
@@ -21,23 +28,50 @@ import { EventLogParserService } from 'src/app/services/event-log-parser.service
         MatFormFieldModule,
         MatInputModule,
         ReactiveFormsModule,
+        CommonModule,
     ],
     templateUrl: './event-log-dialog.component.html',
     styleUrl: './event-log-dialog.component.css',
 })
-export class EventLogDialogComponent {
+export class EventLogDialogComponent implements OnInit {
+    public eventLogControl = new FormControl('', {
+        validators: [
+            Validators.required,
+            this.validateFormControlInput.bind(this),
+        ],
+        updateOn: 'change',
+    });
+
     constructor(
         private dialogRef: MatDialogRef<EventLogDialogComponent, EventLog>,
         private eventLogParserService: EventLogParserService,
         private calculateDfgService: CalculateDfgService,
         private calculateCoordinatesService: CalculateCoordinatesService,
+        private eventLogValidationService: EventLogValidationService,
     ) {}
 
-    public eventLogInput: string = '';
+    ngOnInit(): void {
+        this.eventLogControl.markAsTouched();
+        this.eventLogControl.updateValueAndValidity();
+    }
+
+    private validateFormControlInput(
+        control: FormControl,
+    ): { [key: string]: boolean } | null {
+        const input = control.value;
+        if (input && !this.eventLogValidationService.validateInput(input)) {
+            return { invalidInput: true };
+        }
+        return null;
+    }
 
     public onOkClick(): void {
+        if (this.eventLogControl.invalid) {
+            return;
+        }
+
         const eventLog: EventLog = this.eventLogParserService.parse(
-            this.eventLogInput,
+            this.eventLogControl.value!,
         );
         const dfg: Dfg = this.calculateDfgService.calculate(eventLog);
         const graph =

--- a/src/app/services/event-log-validation.service.spec.ts
+++ b/src/app/services/event-log-validation.service.spec.ts
@@ -1,16 +1,33 @@
-import { TestBed } from '@angular/core/testing';
-
 import { EventLogValidationService } from './event-log-validation.service';
 
 describe('EventLogValidationService', () => {
-  let service: EventLogValidationService;
+    let sut: EventLogValidationService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(EventLogValidationService);
-  });
+    beforeEach(() => {
+        sut = new EventLogValidationService();
+    });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
-  });
+    it('empty string', () => {
+        const input: string = '';
+        const result = sut.validateInput(input);
+        expect(result).toBeFalse();
+    });
+
+    it('string starts with a plus "+" ', () => {
+        const input: string = '+A B C + D';
+        const result = sut.validateInput(input);
+        expect(result).toBeFalse();
+    });
+
+    it('string / Traces separated by two plusses "++" ', () => {
+        const input: string = 'A B C ++ D';
+        const result = sut.validateInput(input);
+        expect(result).toBeFalse();
+    });
+
+    it('valid string / event log ', () => {
+        const input: string = 'A B C + X Y Z + Test Test1 Test2';
+        const result = sut.validateInput(input);
+        expect(result).toBeTrue();
+    });
 });

--- a/src/app/services/event-log-validation.service.spec.ts
+++ b/src/app/services/event-log-validation.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EventLogValidationService } from './event-log-validation.service';
+
+describe('EventLogValidationService', () => {
+  let service: EventLogValidationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(EventLogValidationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/event-log-validation.service.spec.ts
+++ b/src/app/services/event-log-validation.service.spec.ts
@@ -1,6 +1,6 @@
 import { EventLogValidationService } from './event-log-validation.service';
 
-describe('EventLogValidationService', () => {
+describe('EventLogValidationService False Cases', () => {
     let sut: EventLogValidationService;
 
     beforeEach(() => {
@@ -13,20 +13,39 @@ describe('EventLogValidationService', () => {
         expect(result).toBeFalse();
     });
 
-    it('string starts with a plus "+" ', () => {
+    it('event log starts with a plus "+" ', () => {
         const input: string = '+A B C + D';
         const result = sut.validateInput(input);
         expect(result).toBeFalse();
     });
 
-    it('string / Traces separated by two plusses "++" ', () => {
+    it('string / Traces separated by a plus two times in a row "++" ', () => {
         const input: string = 'A B C ++ D';
         const result = sut.validateInput(input);
         expect(result).toBeFalse();
     });
 
+    it('too many whitespaces means more than one whitespace betweens Strings', () => {
+        const input: string = 'A   B';
+        const result = sut.validateInput(input);
+        expect(result).toBeFalse();
+    });
+});
+
+describe('EventLogValidationService True Cases', () => {
+    let sut: EventLogValidationService;
+
+    beforeEach(() => {
+        sut = new EventLogValidationService();
+    });
     it('valid string / event log ', () => {
         const input: string = 'A B C + X Y Z + Test Test1 Test2';
+        const result = sut.validateInput(input);
+        expect(result).toBeTrue();
+    });
+
+    it('valid string / event log an optional whitespace around the plus', () => {
+        const input: string = 'A+B C + X Y Z +N M +L K';
         const result = sut.validateInput(input);
         expect(result).toBeTrue();
     });

--- a/src/app/services/event-log-validation.service.ts
+++ b/src/app/services/event-log-validation.service.ts
@@ -11,7 +11,7 @@ export class EventLogValidationService {
         gefolgt von einem Leerzeichen gefolgt einem String ohne Plus und Leerzeichen (0 bis n mal)*/
 
     private readonly validEventLogPattern =
-        /^[^\+\s]+((?:\s[^\+\s]+)*|(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*)*$/;
+        /^[^\+\s]+((?:\s[^\+\s]+)*|(?:\s*\+\s*[^\+\s]+)*(?:\s[^\+\s]+)*)*$/;
     constructor() {}
 
     validateInput(input: string): boolean {

--- a/src/app/services/event-log-validation.service.ts
+++ b/src/app/services/event-log-validation.service.ts
@@ -4,29 +4,17 @@ import { Injectable } from '@angular/core';
     providedIn: 'root',
 })
 export class EventLogValidationService {
-    /* [^\+]+ = 1 bis n beliebige Zeichen außer "+"
-    (?:\+[^\+]+)* = 0 bis n mal ("+" gefolgt von einem String bestehend aus 1 bis n beliebigen Zeichen außer "+") */
+    /* [^\+\s]+ = 1 bis n beliebige Zeichen außer "+" und Leerzeichen
+    ((?:\s[^\+\s]+)*|(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*)* eine Alternative folgt
+        entweeder ein Leerzeichen gefolgt von einem String ohne Plus und Leerzeichen (0 bis n mal) ODER
+        ein Plus mit optionalen Leerzeichen gefolgt von einem String ohne Plus und Leerzeichen (0 bis n mal) 
+        gefolgt von einem Leerzeichen gefolgt einem String ohne Plus und Leerzeichen (0 bis n mal)*/
 
-    private readonly validEventLogPattern = /^[^\+]+(?:\+[^\+]+)*$/;
-    private readonly validEventLogPattern2 =
-        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s\+\s[^\+\s]+)*$/;
-    private readonly validEventLogPattern3 =
-        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s\+\s[^\+\s]+)*(?:\s[^\+\s]+)*$/;
-    private readonly validEventLogPattern4 =
-        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*$/;
-    private readonly validEventLogPattern5 =
-        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*$/;
-    private readonly validEventLogPattern6 =
-        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*$/;
-    private readonly validEventLogPattern7 =
-        /^[^\+\s]+((?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*)*$/;
-    private readonly validEventLogPattern8 =
-        /^[^\+\s]+(?:\s?[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*$/;
-    private readonly validEventLogPattern9 =
+    private readonly validEventLogPattern =
         /^[^\+\s]+((?:\s[^\+\s]+)*|(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*)*$/;
     constructor() {}
 
     validateInput(input: string): boolean {
-        return this.validEventLogPattern9.test(input);
+        return this.validEventLogPattern.test(input);
     }
 }

--- a/src/app/services/event-log-validation.service.ts
+++ b/src/app/services/event-log-validation.service.ts
@@ -8,9 +8,25 @@ export class EventLogValidationService {
     (?:\+[^\+]+)* = 0 bis n mal ("+" gefolgt von einem String bestehend aus 1 bis n beliebigen Zeichen außer "+") */
 
     private readonly validEventLogPattern = /^[^\+]+(?:\+[^\+]+)*$/;
+    private readonly validEventLogPattern2 =
+        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s\+\s[^\+\s]+)*$/;
+    private readonly validEventLogPattern3 =
+        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s\+\s[^\+\s]+)*(?:\s[^\+\s]+)*$/;
+    private readonly validEventLogPattern4 =
+        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*$/;
+    private readonly validEventLogPattern5 =
+        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*$/;
+    private readonly validEventLogPattern6 =
+        /^[^\+\s]+(?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*$/;
+    private readonly validEventLogPattern7 =
+        /^[^\+\s]+((?:\s[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*)*$/;
+    private readonly validEventLogPattern8 =
+        /^[^\+\s]+(?:\s?[^\+\s]+)*(?:\s?\+\s?[^\+\s]+)*$/;
+    private readonly validEventLogPattern9 =
+        /^[^\+\s]+((?:\s[^\+\s]+)*|(?:\s?\+\s?[^\+\s]+)*(?:\s[^\+\s]+)*)*$/;
     constructor() {}
 
     validateInput(input: string): boolean {
-        return this.validEventLogPattern.test(input);
+        return this.validEventLogPattern9.test(input);
     }
 }

--- a/src/app/services/event-log-validation.service.ts
+++ b/src/app/services/event-log-validation.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class EventLogValidationService {
+    /* [^\+]+ = 1 bis n beliebige Zeichen außer "+"
+    (?:\+[^\+]+)* = 0 bis n mal ("+" gefolgt von einem String bestehend aus 1 bis n beliebigen Zeichen außer "+") */
+
+    private readonly validEventLogPattern = /^[^\+]+(?:\+[^\+]+)*$/;
+    constructor() {}
+
+    validateInput(input: string): boolean {
+        return this.validEventLogPattern.test(input);
+    }
+}


### PR DESCRIPTION
Durch einen RegEx-Ausdruck wird folgendes gerpüft:
- eine leere Eingabe unterbunden
- führende Plus-Zeichen vor den Aktivitäten unterbunden 
- bzw. mehrere Plus-Zeichen Zwischen den Traces unterbunden
- zu viele Leerzeichen zwischen den Aktivitäten werden unterbunden (genau 1 Leerzeichen dazwischen erlaubt)
- Die Leerzeichen vor und nach dem Plus, welches die Traces trennt, sind optional (beliebig viele zulässig)

Anpassungen am Dialog:
- Die Event-Log-Dialog-Komponente gibt entsprechende Rückmeldung bei Fehleingaben.
- Der Ok-Button ist deaktiviert bei Fehleingaben.
- Das Abschicken des EventLogs (Klicken des OK-Buttons) kann auch per Drücken der Enter-Taste durchgeführt werden
- Beim Öffnen des Dialogs wird der Cursor direkt in das Input-Feld gesetzt
- Clear-Button zum Löschen der Textarea ergänzt