### PR TITLE
SCRUM-42-Zuruecksetzen-des-Counters-fuer-die-DFG-Ids

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,9 +7,6 @@ import { CalculateDfgService } from './services/calculate-dfg.service';
 import { Dfg } from './classes/dfg/dfg';
 import { PetriNetManagementService } from './services/petri-net-management.service';
 import { ShowFeedbackService } from './services/show-feedback.service';
-import { CalculatePetriNetService } from './services/calculate-petri-net.service';
-import { PetriNet } from './classes/petrinet/petri-net';
-import { DfgBuilder } from './classes/dfg/dfg';
 import { FallThroughHandlingService } from './services/fall-through-handling.service';
 
 @Component({
@@ -23,7 +20,6 @@ export class AppComponent {
         private _calculateDfgService: CalculateDfgService,
         private _petriNetManagementService: PetriNetManagementService,
         private _feedbackService: ShowFeedbackService,
-        private _pnCalculationService: CalculatePetriNetService,
         private _fallThroughHandlingService: FallThroughHandlingService,
     ) {}
 
@@ -41,6 +37,7 @@ export class AppComponent {
                     return;
                 }
 
+                Dfg.resetIdCount();
                 const dfg: Dfg = this._calculateDfgService.calculate(eventLog);
                 this._petriNetManagementService.initialize(dfg);
             },

--- a/src/app/classes/dfg/dfg.ts
+++ b/src/app/classes/dfg/dfg.ts
@@ -17,7 +17,7 @@ export class Dfg implements PetriNetTransition {
         private readonly _arcs: Arcs,
         private readonly _eventLog: EventLog,
     ) {
-        this.id = 'dfg' + ++Dfg.idCount;
+        this.id = 'DFG' + ++Dfg.idCount;
     }
 
     canBeCutIn(
@@ -124,6 +124,10 @@ export class Dfg implements PetriNetTransition {
             activities: this._activities.asJson(),
             arcs: this._arcs.asJson(),
         };
+    }
+
+    static resetIdCount(): void {
+        this.idCount = 0;
     }
 }
 

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -12,14 +12,12 @@ export class PetriNet {
     private readonly _transitions: PetriNetTransitions =
         new PetriNetTransitions();
     private readonly _arcs: PetriNetArcs = new PetriNetArcs();
-    // private _isInitialized: boolean = false;
 
     constructor(dfg?: Dfg) {
         dfg ? this.initializeOriginDFG(dfg) : undefined;
     }
 
     private initializeOriginDFG(dfg: Dfg): PetriNet {
-        // this._isInitialized = true;
         this._places.addInputPlace().addOutputPlace();
         this._transitions.createTransition('play').createTransition('stop');
 
@@ -219,9 +217,9 @@ export class PetriNet {
         return false;
     }
 
-    // get isInitialized(): boolean {
-    //     return this._isInitialized;
-    // }
+    getDFGs(): Dfg[] {
+        return this._transitions.getAllDFGs();
+    }
 
     get inputPlace(): Place {
         return this._places.input;

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -217,10 +217,6 @@ export class PetriNet {
         return false;
     }
 
-    getDFGs(): Dfg[] {
-        return this._transitions.getAllDFGs();
-    }
-
     get inputPlace(): Place {
         return this._places.input;
     }

--- a/src/app/components/example-event-logs/example-event-logs.component.ts
+++ b/src/app/components/example-event-logs/example-event-logs.component.ts
@@ -77,6 +77,7 @@ export class ExampleEventLogsComponent {
     }
 
     private initializePetriNet(eventLog: EventLog): void {
+        Dfg.resetIdCount();
         const dfg: Dfg = this._calculateDfgService.calculate(eventLog);
         this._petriNetManagementService.initialize(dfg);
     }


### PR DESCRIPTION
Die id wird jedes Mal zurückgesetzt, wenn ein neues Event Log über den Input-Dialog eingegeben oder eines der Beispiel-Eventlogs ausgewählt wird. Damit wird für ein neues Eventlog immer mit DFG1 gestartet