### PR TITLE
SCRUM-14-Kanten-auswaehlbar-machen-Multiselect-3

### DIFF
--- a/src/app/classes/dfg/arcs.ts
+++ b/src/app/classes/dfg/arcs.ts
@@ -170,7 +170,6 @@ export class Arcs {
         return this;
     }
 
-
     getArcs(): Array<DfgArc> {
         return this.arcs;
     }
@@ -188,7 +187,10 @@ export class Arcs {
         return false;
     }
 
-    getArcByStartNameAndEndName(start: string, end: string): DfgArc {
+    getArcByStartNameAndEndName(
+        start: string,
+        end: string,
+    ): DfgArc | undefined {
         for (const arc of this.arcs) {
             if (
                 arc.getStart().asJson() === start &&

--- a/src/app/classes/dfg/arcs.ts
+++ b/src/app/classes/dfg/arcs.ts
@@ -199,7 +199,8 @@ export class Arcs {
                 return arc;
             }
         }
-        throw new Error('Arc not found');
+        return undefined;
+        // throw new Error('Arc not found');
     }
 
     asJson(): ArcJson[] {

--- a/src/app/classes/dfg/dfg.ts
+++ b/src/app/classes/dfg/dfg.ts
@@ -82,7 +82,7 @@ export class Dfg implements PetriNetTransition {
     thus same behavior as the arc is clicked in petrinet
     */
     getArc(start: string, end: string): DfgArc {
-        return this.arcs.getArcByStartNameAndEndName(start, end);
+        return this.arcs.getArcByStartNameAndEndName(start, end)!;
     }
 
     get activities(): Activities {

--- a/src/app/classes/petrinet/petri-net-transitions.ts
+++ b/src/app/classes/petrinet/petri-net-transitions.ts
@@ -54,16 +54,6 @@ export class PetriNetTransitions {
         return true;
     }
 
-    // getAllDFGs(): Dfg[] {
-    //     const dfgs: Dfg[] = [];
-    //     for (const transition of this.transitions) {
-    //         if (transition instanceof Dfg) {
-    //             dfgs.push(transition);
-    //         }
-    //     }
-    //     return dfgs;
-    // }
-
     getLastTransition(): PetriNetTransition {
         return this._transitions[this._transitions.length - 1];
     }

--- a/src/app/classes/petrinet/petri-net-transitions.ts
+++ b/src/app/classes/petrinet/petri-net-transitions.ts
@@ -54,15 +54,15 @@ export class PetriNetTransitions {
         return true;
     }
 
-    getAllDFGs(): Dfg[] {
-        const dfgs: Dfg[] = [];
-        for (const transition of this.transitions) {
-            if (transition instanceof Dfg) {
-                dfgs.push(transition);
-            }
-        }
-        return dfgs;
-    }
+    // getAllDFGs(): Dfg[] {
+    //     const dfgs: Dfg[] = [];
+    //     for (const transition of this.transitions) {
+    //         if (transition instanceof Dfg) {
+    //             dfgs.push(transition);
+    //         }
+    //     }
+    //     return dfgs;
+    // }
 
     getLastTransition(): PetriNetTransition {
         return this._transitions[this._transitions.length - 1];

--- a/src/app/classes/petrinet/petri-net-transitions.ts
+++ b/src/app/classes/petrinet/petri-net-transitions.ts
@@ -53,4 +53,14 @@ export class PetriNetTransitions {
         }
         throw new Error('Transition not found');
     }
+
+    getAllDFGs(): Array<Dfg> {
+        const dfgs: Array<Dfg> = new Array<Dfg>();
+        for (const transition of this._transitions) {
+            if (transition instanceof Dfg) {
+                dfgs.push(transition);
+            }
+        }
+        return dfgs;
+    }
 }

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -219,10 +219,6 @@ export class PetriNet {
         return false;
     }
 
-    // getDFGs(): Dfg[] {
-    //     return this._transitions.getAllDFGs();
-    // }
-
     // get isInitialized(): boolean {
     //     return this._isInitialized;
     // }

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -219,9 +219,9 @@ export class PetriNet {
         return false;
     }
 
-    getDFGs(): Dfg[] {
-        return this._transitions.getAllDFGs();
-    }
+    // getDFGs(): Dfg[] {
+    //     return this._transitions.getAllDFGs();
+    // }
 
     // get isInitialized(): boolean {
     //     return this._isInitialized;

--- a/src/app/classes/petrinet/petri-net.ts
+++ b/src/app/classes/petrinet/petri-net.ts
@@ -170,4 +170,8 @@ export class PetriNet {
     get arcs(): PetriNetArcs {
         return this._arcs;
     }
+
+    public getDFGs(): Array<Dfg> {
+        return this._transitions.getAllDFGs();
+    }
 }

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -82,9 +82,50 @@ export class DrawingArcComponent {
     color: string = environment.drawingElements.arcs.color;
     markerColor = environment.drawingElements.arcs.color;
     arrow = '#arrowhead';
+    //isActive = this.collectArcsService.arcIsActive;
     isActive = false;
 
+    // lines.forEach((line) => {
+    //     line.addEventListener("mouseenter", () => handleMouseEnter(line, "red"));
+    //     line.addEventListener("mouseleave", () => handleMouseLeave(line));
+    // });
+
+    // ngOnInit() {
+    //     const elements = document.getElementsByTagName('line');
+    //     Array.from(elements).forEach((element) => {
+    //         console.log(element);
+    //     });
+    // }
+
+    // ngAfterViewInit(): void {
+    //     this.initializeHoverEffects();
+    // }
+
+    // private initializeHoverEffects(): void {
+    //     const lines = document.querySelectorAll('rect');
+
+    //     lines.forEach((line: Element) => {
+    //         line.addEventListener('mouseenter', () =>
+    //             this.handleMouseOver(line, 'red'),
+    //         );
+    //         line.addEventListener('mouseleave', () =>
+    //             this.handleMouseLeave(line),
+    //         );
+    //     });
+    // }
+
+    // private handleMouseOver = (element: any, color: string) => {
+    //     element.style.setProperty('--color', color);
+    // };
+
+    // private handleMouseLeave = (element: any) => {
+    //     element.style.removeProperty('--color');
+    // };
+
     changeLineColorOver(color: string): void {
+        // console.log('Im Mouseover - Farbe: ' + color);
+
+        // document.documentElement.style.setProperty('--color', color);
         this.color = color;
         this.arrow = '#arrowhead-hover' + this.arc.x1 + this.arc.y1;
     }
@@ -95,8 +136,6 @@ export class DrawingArcComponent {
         if (this.isActive === true) {
             this.markerColor = 'red';
         }
-
-        console.log(this.markerColor);
     }
 
     onLineClick(arc: Arc): void {
@@ -108,15 +147,15 @@ export class DrawingArcComponent {
                 this.collectArcsService.updateCollectedArcs(arc);
 
                 if (this.isActive === true) {
-                    console.log('alte MarkerColor: ' + this.markerColor);
+                    // console.log('alte MarkerColor: ' + this.markerColor);
                     this.markerColor = environment.drawingElements.arcs.color;
-                    console.log('neue MarkerColor: ' + this.markerColor);
+                    // console.log('neue MarkerColor: ' + this.markerColor);
 
                     this.isActive = false;
                 } else {
-                    console.log('alte MarkerColor: ' + this.markerColor);
+                    // console.log('alte MarkerColor: ' + this.markerColor);
                     this.markerColor = 'red';
-                    console.log('neue MarkerColor: ' + this.markerColor);
+                    // console.log('neue MarkerColor: ' + this.markerColor);
                     this.isActive = true;
                 }
             } else {

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -19,13 +19,13 @@ import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="markerColor"
-                    [attr.stroke]="markerColor"
+                    [attr.fill]="'black'"
+                    [attr.stroke]="'black'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>
             <svg:marker
-                [attr.id]="'arrowhead-hover' + arc.x1 + arc.y1"
+                id="arrowhead-red"
                 viewBox="0 0 10 10"
                 markerWidth="10"
                 markerHeight="10"
@@ -63,7 +63,7 @@ import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
             [attr.y2]="arc.y2"
             [attr.stroke]="'black'"
             [attr.stroke-width]="width"
-            [attr.marker-end]="'url(' + arrow + ')'"
+            marker-end="url(#arrowhead)"
         />
     `,
     styles: `
@@ -147,7 +147,8 @@ export class DrawingArcComponent {
 
         if (line && !line.classList.contains('active')) {
             line.classList.add('hovered');
-            this.arrow = '#arrowhead-hover' + this.arc.x1 + this.arc.y1;
+            // this.arrow = '#arrowhead-hover' + this.arc.x1 + this.arc.y1;
+            line.setAttribute('marker-end', 'url(#arrowhead-red)');
         }
 
         // console.log('Im Mouseover - Farbe: ' + color);
@@ -168,7 +169,7 @@ export class DrawingArcComponent {
 
         if (line && !line.classList.contains('active')) {
             line.classList.remove('hovered');
-            this.arrow = '#arrowhead';
+            line.setAttribute('marker-end', 'url(#arrowhead)');
         }
 
         // this.arrow = '#arrowhead';

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -76,7 +76,7 @@ import { CollectArcsService } from 'src/app/services/collect-arcs.service';
 export class DrawingArcComponent {
     @Input({ required: true }) arc!: Arc;
 
-    collectArcsService: CollectArcsService = new CollectArcsService();
+    constructor(private collectArcsService: CollectArcsService) {}
 
     readonly width: number = environment.drawingElements.arcs.width;
     color: string = environment.drawingElements.arcs.color;
@@ -91,30 +91,39 @@ export class DrawingArcComponent {
     changeLineColorOut(color: string): void {
         this.arrow = '#arrowhead';
         this.color = color;
-        console.log('isActive: ' + this.isActive);
+
         if (this.isActive === true) {
             this.markerColor = 'red';
-            console.log('markerColor: ' + this.markerColor);
         }
+
+        console.log(this.markerColor);
     }
 
     onLineClick(arc: Arc): void {
-        if (this.isActive === true) {
-            this.markerColor = environment.drawingElements.arcs.color;
-            console.log(this.markerColor);
-            this.isActive = false;
-        } else {
-            this.markerColor = 'red';
-            console.log(this.markerColor);
-            this.isActive = true;
-        }
+        if (this.collectArcsService.isDFGArc(arc)) {
+            console.log('Arc ist DFFGArc');
 
-        console.log(arc);
+            if (this.collectArcsService.isArcinSameDFG(arc)) {
+                console.log('Arc in same DFG');
+                this.collectArcsService.updateCollectedArcs(arc);
 
-        if (this.collectArcsService.isValidArc(arc)) {
-            this.collectArcsService.updateCollectedArcs(arc);
+                if (this.isActive === true) {
+                    console.log('alte MarkerColor: ' + this.markerColor);
+                    this.markerColor = environment.drawingElements.arcs.color;
+                    console.log('neue MarkerColor: ' + this.markerColor);
+
+                    this.isActive = false;
+                } else {
+                    console.log('alte MarkerColor: ' + this.markerColor);
+                    this.markerColor = 'red';
+                    console.log('neue MarkerColor: ' + this.markerColor);
+                    this.isActive = true;
+                }
+            } else {
+                console.log('Arc not in same DFG');
+            }
         } else {
-            //werfe Fehlermeldung mit Feedback-Service
+            console.log('Arc ist keine DFGArc');
         }
     }
 

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { Arc } from '../models';
 import { environment } from 'src/environments/environment';
+import { CollectArcsService } from 'src/app/services/collect-arcs.service';
 
 @Component({
     selector: 'svg:g[app-drawing-arc]',
@@ -17,28 +18,119 @@ import { environment } from 'src/environments/environment';
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="color"
-                    [attr.stroke]="color"
+                    [attr.fill]="markerColor"
+                    [attr.stroke]="markerColor"
+                    [attr.stroke-width]="width"
+                ></svg:path>
+            </svg:marker>
+            <svg:marker
+                [attr.id]="'arrowhead-hover' + arc.x1 + arc.y1"
+                viewBox="0 0 10 10"
+                markerWidth="10"
+                markerHeight="10"
+                refX="5"
+                refY="5"
+                orient="auto-start-reverse"
+            >
+                <svg:path
+                    d="M 1,1 L 9,5 L 1,9 Z"
+                    [attr.fill]="'red'"
+                    [attr.stroke]="'red'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>
         </svg:defs>
 
+        <svg:rect
+            [attr.x]="arc.x1"
+            [attr.y]="arc.y1 - 5"
+            [attr.width]="arc.x2 - arc.x1"
+            [attr.height]="rectheight"
+            fill="transparent"
+            pointer-events="all"
+            [attr.transform]="
+                'rotate(' + rotationAngle + ',' + arc.x1 + ',' + arc.y1 + ')'
+            "
+            (mouseover)="changeLineColorOver('red')"
+            (mouseout)="changeLineColorOut('black')"
+            (click)="onLineClick(arc)"
+        ></svg:rect>
         <svg:line
             [attr.x1]="arc.x1"
             [attr.y1]="arc.y1"
             [attr.x2]="arc.x2"
             [attr.y2]="arc.y2"
-            [attr.stroke]="color"
+            [attr.stroke]="isActive ? 'red' : color"
             [attr.stroke-width]="width"
-            marker-end="url(#arrowhead)"
+            [attr.marker-end]="'url(' + arrow + ')'"
+            [attr.clicked]="isActive"
         />
     `,
-    styles: ``,
+    styles: `
+        rect:hover {
+            cursor: pointer;
+            /* marker-end: url(arrow);*/
+        }
+    `,
 })
 export class DrawingArcComponent {
     @Input({ required: true }) arc!: Arc;
 
-    readonly color: string = environment.drawingElements.arcs.color;
+    collectArcsService: CollectArcsService = new CollectArcsService();
+
     readonly width: number = environment.drawingElements.arcs.width;
+    color: string = environment.drawingElements.arcs.color;
+    markerColor = environment.drawingElements.arcs.color;
+    arrow = '#arrowhead';
+    isActive = false;
+
+    changeLineColorOver(color: string): void {
+        this.color = color;
+        this.arrow = '#arrowhead-hover' + this.arc.x1 + this.arc.y1;
+    }
+    changeLineColorOut(color: string): void {
+        this.arrow = '#arrowhead';
+        this.color = color;
+        console.log('isActive: ' + this.isActive);
+        if (this.isActive === true) {
+            this.markerColor = 'red';
+            console.log('markerColor: ' + this.markerColor);
+        }
+    }
+
+    onLineClick(arc: Arc): void {
+        if (this.isActive === true) {
+            this.markerColor = environment.drawingElements.arcs.color;
+            console.log(this.markerColor);
+            this.isActive = false;
+        } else {
+            this.markerColor = 'red';
+            console.log(this.markerColor);
+            this.isActive = true;
+        }
+
+        console.log(arc);
+
+        if (this.collectArcsService.isValidArc(arc)) {
+            this.collectArcsService.updateCollectedArcs(arc);
+        } else {
+            //werfe Fehlermeldung mit Feedback-Service
+        }
+    }
+
+    rectheight = 10;
+
+    get rectWidth(): number {
+        return Math.sqrt(
+            Math.pow(this.arc.x2 - this.arc.x1, 2) +
+                Math.pow(this.arc.y2 - this.arc.y1, 2),
+        );
+    }
+
+    get rotationAngle(): number {
+        return (
+            Math.atan2(this.arc.y2 - this.arc.y1, this.arc.x2 - this.arc.x1) *
+            (180 / Math.PI)
+        );
+    }
 }

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -19,8 +19,8 @@ import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="'black'"
-                    [attr.stroke]="'black'"
+                    [attr.fill]="color"
+                    [attr.stroke]="color"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>
@@ -42,41 +42,34 @@ import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
             </svg:marker>
         </svg:defs>
 
-        <svg:rect
-            [attr.x]="arc.x1"
-            [attr.y]="arc.y1 - 5"
-            [attr.width]="this.rectWidth(arc)"
-            [attr.height]="rectheight"
+        <svg:path
+            [attr.d]="pathForLine(arc)"
+            [attr.stroke-width]="10"
+            [attr.fill]="'none'"
             fill="transparent"
             pointer-events="all"
-            [attr.transform]="
-                'rotate(' + rotationAngle + ',' + arc.x1 + ',' + arc.y1 + ')'
-            "
             (mouseover)="changeLineColorOver($event)"
             (mouseout)="changeLineColorOut($event)"
             (click)="onLineClick($event, arc)"
-        ></svg:rect>
-        <svg:line
-            [attr.x1]="arc.x1"
-            [attr.y1]="arc.y1"
-            [attr.x2]="arc.x2"
-            [attr.y2]="arc.y2"
+        ></svg:path>
+        <svg:path
+            [attr.d]="pathForLine(arc)"
             [attr.stroke]="'black'"
             [attr.stroke-width]="width"
+            [attr.fill]="'none'"
             marker-end="url(#arrowhead)"
-        />
+        ></svg:path>
     `,
     styles: `
-        rect:hover {
+        path:hover {
             cursor: pointer;
-            /* marker-end: url(arrow);*/
         }
 
-        line.active {
+        path.active {
             stroke: red !important;
         }
 
-        line.hovered {
+        path.hovered {
             stroke: red !important;
         }
     `,
@@ -90,135 +83,49 @@ export class DrawingArcComponent {
     ) {}
 
     readonly width: number = environment.drawingElements.arcs.width;
-    color: string = environment.drawingElements.arcs.color;
-    markerColor = environment.drawingElements.arcs.color;
-    arrow = '#arrowhead';
-    //isActive = this.collectArcsService.arcIsActive;
-    // isActive = false;
-    svg: SVGSVGElement = document.getElementsByTagName(
+    readonly color: string = environment.drawingElements.arcs.color;
+    readonly svg: SVGSVGElement = document.getElementsByTagName(
         'svg',
     )[0] as SVGSVGElement;
 
-    // lines.forEach((line) => {
-    //     line.addEventListener("mouseenter", () => handleMouseEnter(line, "red"));
-    //     line.addEventListener("mouseleave", () => handleMouseLeave(line));
-    // });
-
-    // ngOnInit() {
-    //     const elements = document.getElementsByTagName('line');
-    //     Array.from(elements).forEach((element) => {
-    //         console.log(element);
-    //     });
-    // }
-
-    // ngAfterViewInit(): void {
-    //     this.initializeHoverEffects();
-    // }
-
-    // private initializeHoverEffects(): void {
-    //     const lines = document.querySelectorAll('rect');
-
-    //     lines.forEach((line: Element) => {
-    //         line.addEventListener('mouseenter', () =>
-    //             this.handleMouseOver(line, 'red'),
-    //         );
-    //         line.addEventListener('mouseleave', () =>
-    //             this.handleMouseLeave(line),
-    //         );
-    //     });
-    // }
-
-    // private handleMouseOver = (element: any, color: string) => {
-    //     element.style.setProperty('--color', color);
-    // };
-
-    // private handleMouseLeave = (element: any) => {
-    //     element.style.removeProperty('--color');
-    // };
-
     changeLineColorOver(event: Event): void {
-        const rects = Array.from(this.svg.querySelectorAll('rect'));
-        const lines = Array.from(this.svg.querySelectorAll('line'));
-
         const rect: SVGRectElement = event.target as SVGRectElement;
-        const rectIndex = rects.indexOf(rect);
-
         const line = rect.nextElementSibling as SVGLineElement;
 
         if (line && !line.classList.contains('active')) {
             line.classList.add('hovered');
-            // this.arrow = '#arrowhead-hover' + this.arc.x1 + this.arc.y1;
             line.setAttribute('marker-end', 'url(#arrowhead-red)');
         }
-
-        // console.log('Im Mouseover - Farbe: ' + color);
-
-        // document.documentElement.style.setProperty('--color', color);
-        // console.log(event);
-
-        // this.color = 'red';
     }
     changeLineColorOut(event: Event): void {
-        const rects = Array.from(this.svg.querySelectorAll('rect'));
-        const lines = Array.from(this.svg.querySelectorAll('line'));
-
         const rect = event.target as SVGRectElement;
-        const rectIndex = rects.indexOf(rect);
-
         const line = rect.nextElementSibling as SVGLineElement;
 
         if (line && !line.classList.contains('active')) {
             line.classList.remove('hovered');
             line.setAttribute('marker-end', 'url(#arrowhead)');
         }
-
-        // this.arrow = '#arrowhead';
-        // this.color = color;
-
-        // if (this.isActive === true) {
-        //     this.markerColor = 'red';
-        // }
     }
 
     onLineClick(event: Event, arc: Arc): void {
-        const rects = Array.from(this.svg.querySelectorAll('rect'));
-        const lines = Array.from(this.svg.querySelectorAll('line'));
-
         const rect = event.target as SVGRectElement;
-        const rectIndex = rects.indexOf(rect);
-
         const line = rect.nextElementSibling as SVGLineElement;
 
         if (this.collectArcsService.isDFGArc(arc)) {
-            console.log('Arc ist DFFGArc');
+            // console.log('Arc ist DFFGArc');
 
             if (this.collectArcsService.isArcinSameDFG(arc)) {
-                console.log('Arc in same DFG');
+                // console.log('Arc in same DFG');
                 if (line) {
                     line.classList.toggle('active');
                 }
 
                 this.collectArcsService.updateCollectedArcs(arc);
-
-                // if (this.isActive === true) {
-                //     // console.log('alte MarkerColor: ' + this.markerColor);
-                //     this.markerColor = environment.drawingElements.arcs.color;
-                //     // console.log('neue MarkerColor: ' + this.markerColor);
-
-                //     this.isActive = false;
-                // } else {
-                //     // console.log('alte MarkerColor: ' + this.markerColor);
-                //     this.markerColor = 'red';
-                //     // console.log('neue MarkerColor: ' + this.markerColor);
-                //     this.isActive = true;
-                // }
             } else {
                 this.feedbackService.showMessage('Arc not in same DFG', true);
-                // console.log('Arc not in same DFG');
             }
         } else {
             this.feedbackService.showMessage('Arc is not a DFGArc', true);
-            // console.log('Arc ist keine DFGArc');
         }
     }
 
@@ -238,5 +145,33 @@ export class DrawingArcComponent {
             Math.atan2(this.arc.y2 - this.arc.y1, this.arc.x2 - this.arc.x1) *
             (180 / Math.PI)
         );
+    }
+
+    pathForLine(arc: Arc): string {
+        if (!this.pathNecessary(arc)) {
+            return `M ${arc.x1} ${arc.y1} L ${arc.x2} ${arc.y2}`;
+        }
+
+        let controlPointX = (arc.x1 + arc.x2) / 2;
+        let controlPointY = Math.min(arc.start.y, arc.end.y);
+
+        if (arc.start.y > arc.end.y) {
+            controlPointY = Math.min(arc.start.y, arc.end.y) + 100;
+        }
+
+        if (arc.start.y === arc.end.y) {
+            if (arc.start.x > arc.end.x) {
+                controlPointY = Math.min(arc.start.y, arc.end.y) - 30;
+            }
+            if (arc.start.x <= arc.end.x) {
+                controlPointY = Math.min(arc.start.y, arc.end.y) + 30;
+            }
+        }
+
+        return `M ${arc.x1} ${arc.y1} Q ${controlPointX} ${controlPointY} ${arc.x2} ${arc.y2}`;
+    }
+
+    private pathNecessary(arc: Arc): boolean {
+        return this.collectArcsService.overlayArcsExistsInDFGs(arc);
     }
 }

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -112,10 +112,7 @@ export class DrawingArcComponent {
         const line = rect.nextElementSibling as SVGLineElement;
 
         if (this.collectArcsService.isDFGArc(arc)) {
-            // console.log('Arc ist DFFGArc');
-
             if (this.collectArcsService.isArcinSameDFG(arc)) {
-                // console.log('Arc in same DFG');
                 if (line) {
                     line.classList.toggle('active');
                 }

--- a/src/app/services/collect-arcs.service.spec.ts
+++ b/src/app/services/collect-arcs.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CollectArcsService } from './collect-arcs.service';
+
+describe('CollectArcsService', () => {
+  let service: CollectArcsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CollectArcsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@angular/core';
+import { Arcs, DfgArc } from '../classes/dfg/arcs';
+import {
+    PetriNetArcs,
+    PlaceToTransitionArc,
+    TransitionToPlaceArc,
+} from '../classes/petrinet/petri-net-arcs';
+import { PetriNet } from '../classes/petrinet/petri-net';
+import { Dfg, DfgBuilder } from '../classes/dfg/dfg';
+import { Subscription } from 'rxjs';
+import { Arc } from '../components/drawing-area/models';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class CollectArcsService {
+    constructor() {}
+    private petriNet!: PetriNet;
+    private _collectedArcs: Arcs = new Arcs();
+    private _acutalDFG = undefined;
+
+    // private petriNetManagementService: PetriNetManagementService =
+    //     new PetriNetManagementService();
+    // private _sub = this.petriNetManagementService.petriNet$.subscribe(
+    //     (petriNetSub) => {
+    //         this.petriNet = petriNetSub;
+    //     },
+    // );
+
+    // const petriNet =
+    //dfg = new DfgBuilder().build();
+    //petriNet = new PetriNet(this.dfg);
+
+    //
+
+    get collectedArcs(): Arcs {
+        return this._collectedArcs;
+    }
+
+    public isValidArc(arc: Arc): boolean {
+        if (this._acutalDFG === undefined) {
+            //setze actualDFG auf DFG
+        }
+
+        if (true) {
+            //wenn Arc in actualDFG
+            return true;
+        }
+
+        return false;
+    }
+
+    //Arcs von DFG holen und nicht von Petri-Netz
+    public updateCollectedArcs(arc: Arc): void {
+        let dfgArc: DfgArc; //getDFGArc(arc)
+
+        if (this._collectedArcs.getArcs().includes(dfgArc)) {
+            const indexArcInCollectedArcs = this._collectedArcs
+                .getArcs()
+                .indexOf(dfgArc);
+            this._collectedArcs.getArcs().splice(indexArcInCollectedArcs);
+        }
+
+        if (this._collectedArcs.isEmpty()) {
+            this._acutalDFG = undefined;
+        }
+    }
+}

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -122,8 +122,6 @@ export class CollectArcsService {
         } else {
             this._currentDFG = this.getDFG(arc);
         }
-
-        // console.log(this._collectedArcs);
     }
 
     private getDFG(arc: Arc): Dfg | undefined {

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -17,7 +17,9 @@ import { PetriNetManagementService } from './petri-net-management.service';
 export class CollectArcsService {
     private petriNet!: PetriNet;
     private _collectedArcs: Arcs = new Arcs();
-    private _acutalDFG: Dfg | undefined;
+    private _currentDFG: Dfg | undefined;
+
+    // arcIsActive: boolean = false;
 
     constructor(private petriNetManagementService: PetriNetManagementService) {
         this.petriNetManagementService.petriNet$.subscribe((petriNetSub) => {
@@ -28,6 +30,27 @@ export class CollectArcsService {
     get collectedArcs(): Arcs {
         return this._collectedArcs;
     }
+
+    get currentDFG(): Dfg | undefined {
+        return this._currentDFG;
+    }
+
+    // public resetCollectArcs(): void {
+    //     this._collectedArcs = new Arcs();
+    //     this._currentDFG = undefined;
+
+    //     // this.resetClickedElements();
+    // }
+
+    // private resetClickedElements(): void {
+    //     const elements = document.getElementsByTagName('line');
+    //     Array.from(elements).forEach((element) => {
+    //         element.style.stroke = '';
+    //     });
+    //     // this.arcIsActive = false;
+
+    //     //document.getElementById("mySvg") as SVGSVGElement;
+    // }
 
     private getDFGArcsFromPetriNet(): Array<DfgArc> {
         const dfgArcs = new Array<DfgArc>();
@@ -52,16 +75,18 @@ export class CollectArcsService {
 
     public isArcinSameDFG(arc: Arc): boolean {
         const dfgArcToCheck = this.getDFGArc(arc);
-        if (this._acutalDFG !== undefined) {
+        if (this._currentDFG !== undefined) {
             const arcInDFG: DfgArc | undefined =
-                this._acutalDFG.arcs.getArcByStartNameAndEndName(
+                this._currentDFG.arcs.getArcByStartNameAndEndName(
                     arc.start.id,
                     arc.end.id,
                 );
 
             if (arcInDFG !== undefined) {
-                return false;
+                return true;
             }
+
+            return false;
         }
 
         return true;
@@ -77,6 +102,8 @@ export class CollectArcsService {
 
     public updateCollectedArcs(arc: Arc): void {
         const dfgArc: DfgArc = this.getDFGArc(arc)!;
+        // console.log('dfgarc: ');
+        // console.log(dfgArc);
 
         if (this._collectedArcs.getArcs().includes(dfgArc)) {
             const indexArcInCollectedArcs = this._collectedArcs
@@ -89,19 +116,25 @@ export class CollectArcsService {
         }
 
         if (this._collectedArcs.isEmpty()) {
-            this._acutalDFG = undefined;
+            // console.log('CollectedArcsIsEmpty');
+
+            this._currentDFG = undefined;
         } else {
-            this._acutalDFG = this.getDFG(arc);
+            this._currentDFG = this.getDFG(arc);
         }
 
-        console.log(this._collectedArcs);
+        // console.log(this._collectedArcs);
+        // console.log(this._currentDFG);
     }
 
-    private getDFG(arc: Arc) {
+    private getDFG(arc: Arc): Dfg | undefined {
         const dfgs = this.petriNet.transitions.getAllDFGs();
+        // console.log(dfgs);
 
         for (const dfg of dfgs) {
             if (this.isArcinDFG(arc, dfg)) {
+                // console.log('ArcInDFG');
+
                 return dfg;
             }
         }
@@ -111,15 +144,24 @@ export class CollectArcsService {
 
     public isArcinDFG(arc: Arc, dfg: Dfg | undefined): boolean {
         const dfgArcToCheck = this.getDFGArc(arc);
+        // console.log('DfgArcToCheck:');
+        // console.log(dfgArcToCheck);
+
+        // console.log('DFG: ');
+        // console.log(dfg);
+
         if (dfg !== undefined) {
             const arcInDFG: DfgArc | undefined =
                 dfg.arcs.getArcByStartNameAndEndName(arc.start.id, arc.end.id);
 
+            // console.log('ArcFromDFG');
+            // console.log(arcInDFG);
+
             if (arcInDFG !== undefined) {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -24,8 +24,7 @@ export class CollectArcsService {
     constructor(private petriNetManagementService: PetriNetManagementService) {
         this.petriNetManagementService.petriNet$.subscribe((petriNetSub) => {
             this.petriNet = petriNetSub;
-
-            // this.resetCollectedArcs();
+            this.resetCollectedArcs();
         });
     }
 
@@ -38,10 +37,17 @@ export class CollectArcsService {
     }
 
     public resetCollectedArcs(): void {
+        // console.log('Vor Reset:');
+        // console.log(this._collectedArcs);
+        // console.log(this._currentDFG);
         this._collectedArcs = new Arcs();
         this._currentDFG = undefined;
 
         this.resetClickedElements();
+
+        // console.log('Nach Reset:');
+        // console.log(this._collectedArcs);
+        // console.log(this._currentDFG);
     }
 
     private resetClickedElements(): void {
@@ -49,11 +55,14 @@ export class CollectArcsService {
             'svg',
         )[0] as SVGSVGElement;
 
-        const lines = svg.querySelectorAll('line');
-        lines.forEach((line) => {
-            line.classList.remove('active');
-            line.classList.remove('hovered');
-        });
+        if (svg) {
+            const lines = svg.querySelectorAll('line');
+            lines.forEach((line) => {
+                line.classList.remove('active');
+                line.classList.remove('hovered');
+                line.setAttribute('marker-end', 'url(#arrowhead)');
+            });
+        }
         // const elements = document.getElementsByTagName('line');
         // Array.from(elements).forEach((element) => {
         //     element.style.stroke = '';

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -19,8 +19,6 @@ export class CollectArcsService {
     private _collectedArcs: Arcs = new Arcs();
     private _currentDFG: Dfg | undefined;
 
-    // arcIsActive: boolean = false;
-
     constructor(private petriNetManagementService: PetriNetManagementService) {
         this.petriNetManagementService.petriNet$.subscribe((petriNetSub) => {
             this.petriNet = petriNetSub;
@@ -37,17 +35,10 @@ export class CollectArcsService {
     }
 
     public resetCollectedArcs(): void {
-        // console.log('Vor Reset:');
-        // console.log(this._collectedArcs);
-        // console.log(this._currentDFG);
         this._collectedArcs = new Arcs();
         this._currentDFG = undefined;
 
         this.resetClickedElements();
-
-        // console.log('Nach Reset:');
-        // console.log(this._collectedArcs);
-        // console.log(this._currentDFG);
     }
 
     private resetClickedElements(): void {
@@ -63,12 +54,6 @@ export class CollectArcsService {
                 line.setAttribute('marker-end', 'url(#arrowhead)');
             });
         }
-        // const elements = document.getElementsByTagName('line');
-        // Array.from(elements).forEach((element) => {
-        //     element.style.stroke = '';
-        // });
-        // this.arcIsActive = false;
-        // document.getElementById("mySvg") as SVGSVGElement;
     }
 
     private getDFGArcsFromPetriNet(): Array<DfgArc> {
@@ -121,8 +106,6 @@ export class CollectArcsService {
 
     public updateCollectedArcs(arc: Arc): void {
         const dfgArc: DfgArc = this.getDFGArc(arc)!;
-        // console.log('dfgarc: ');
-        // console.log(dfgArc);
 
         if (this._collectedArcs.getArcs().includes(dfgArc)) {
             const indexArcInCollectedArcs = this._collectedArcs
@@ -135,25 +118,19 @@ export class CollectArcsService {
         }
 
         if (this._collectedArcs.isEmpty()) {
-            // console.log('CollectedArcsIsEmpty');
-
             this._currentDFG = undefined;
         } else {
             this._currentDFG = this.getDFG(arc);
         }
 
         // console.log(this._collectedArcs);
-        // console.log(this._currentDFG);
     }
 
     private getDFG(arc: Arc): Dfg | undefined {
         const dfgs = this.petriNet.transitions.getAllDFGs();
-        // console.log(dfgs);
 
         for (const dfg of dfgs) {
             if (this.isArcinDFG(arc, dfg)) {
-                // console.log('ArcInDFG');
-
                 return dfg;
             }
         }
@@ -163,20 +140,32 @@ export class CollectArcsService {
 
     public isArcinDFG(arc: Arc, dfg: Dfg | undefined): boolean {
         const dfgArcToCheck = this.getDFGArc(arc);
-        // console.log('DfgArcToCheck:');
-        // console.log(dfgArcToCheck);
-
-        // console.log('DFG: ');
-        // console.log(dfg);
 
         if (dfg !== undefined) {
             const arcInDFG: DfgArc | undefined =
                 dfg.arcs.getArcByStartNameAndEndName(arc.start.id, arc.end.id);
 
-            // console.log('ArcFromDFG');
-            // console.log(arcInDFG);
-
             if (arcInDFG !== undefined) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public overlayArcsExistsInDFGs(arc: Arc): boolean {
+        const dfgOfArc = this.getDFG(arc);
+
+        if (dfgOfArc) {
+            const overlayArcs = dfgOfArc.arcs
+                .getArcs()
+                .filter(
+                    (arcInDFG) =>
+                        arcInDFG.getStart().name === arc.end.id &&
+                        arcInDFG.getEnd().name === arc.start.id,
+                );
+
+            if (overlayArcs.length > 0) {
                 return true;
             }
         }

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -24,6 +24,8 @@ export class CollectArcsService {
     constructor(private petriNetManagementService: PetriNetManagementService) {
         this.petriNetManagementService.petriNet$.subscribe((petriNetSub) => {
             this.petriNet = petriNetSub;
+
+            // this.resetCollectedArcs();
         });
     }
 
@@ -35,22 +37,30 @@ export class CollectArcsService {
         return this._currentDFG;
     }
 
-    // public resetCollectArcs(): void {
-    //     this._collectedArcs = new Arcs();
-    //     this._currentDFG = undefined;
+    public resetCollectedArcs(): void {
+        this._collectedArcs = new Arcs();
+        this._currentDFG = undefined;
 
-    //     // this.resetClickedElements();
-    // }
+        this.resetClickedElements();
+    }
 
-    // private resetClickedElements(): void {
-    //     const elements = document.getElementsByTagName('line');
-    //     Array.from(elements).forEach((element) => {
-    //         element.style.stroke = '';
-    //     });
-    //     // this.arcIsActive = false;
+    private resetClickedElements(): void {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
 
-    //     //document.getElementById("mySvg") as SVGSVGElement;
-    // }
+        const lines = svg.querySelectorAll('line');
+        lines.forEach((line) => {
+            line.classList.remove('active');
+            line.classList.remove('hovered');
+        });
+        // const elements = document.getElementsByTagName('line');
+        // Array.from(elements).forEach((element) => {
+        //     element.style.stroke = '';
+        // });
+        // this.arcIsActive = false;
+        // document.getElementById("mySvg") as SVGSVGElement;
+    }
 
     private getDFGArcsFromPetriNet(): Array<DfgArc> {
         const dfgArcs = new Array<DfgArc>();

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -23,10 +23,7 @@ export class PetriNetManagementService {
         return this._isModifiable;
     }
 
-    constructor(
-        private _showFeedbackService: ShowFeedbackService,
-        // private _collectArcService: CollectArcsService,
-    ) {}
+    constructor(private _showFeedbackService: ShowFeedbackService) {}
 
     public initialize(dfg: Dfg): void {
         this._petriNet = new PetriNet(dfg);
@@ -40,7 +37,6 @@ export class PetriNetManagementService {
             this._isModifiable = true;
         }
         this._petriNet$.next(this._petriNet);
-        // this._collectArcService.resetCollectedArcs();
     }
 
     public updatePnByExclusiveCut(
@@ -91,6 +87,5 @@ export class PetriNetManagementService {
             this._isModifiable = true;
         }
         this._petriNet$.next(this._petriNet);
-        // this._collectArcService.resetCollectedArcs();
     }
 }

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -3,6 +3,7 @@ import { PetriNet } from '../classes/petrinet/petri-net';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Dfg } from '../classes/dfg/dfg';
 import { ShowFeedbackService } from './show-feedback.service';
+import { CollectArcsService } from './collect-arcs.service';
 
 @Injectable({
     providedIn: 'root',
@@ -22,7 +23,10 @@ export class PetriNetManagementService {
         return this._isModifiable;
     }
 
-    constructor(private _showFeedbackService: ShowFeedbackService) {}
+    constructor(
+        private _showFeedbackService: ShowFeedbackService,
+        // private _collectArcService: CollectArcsService,
+    ) {}
 
     public initialize(dfg: Dfg): void {
         this._petriNet = new PetriNet(dfg);
@@ -36,6 +40,7 @@ export class PetriNetManagementService {
             this._isModifiable = true;
         }
         this._petriNet$.next(this._petriNet);
+        // this._collectArcService.resetCollectedArcs();
     }
 
     public updatePnByExclusiveCut(
@@ -81,5 +86,6 @@ export class PetriNetManagementService {
             this._isModifiable = true;
         }
         this._petriNet$.next(this._petriNet);
+        // this._collectArcService.resetCollectedArcs();
     }
 }


### PR DESCRIPTION
- Kanten werden beim hovern rot
- wenn Kanten ausgewählt werden, verfärben sie sich rot
- klicke ich auf eine ausgewählte Kante, wird sie schwarz
- liegen Kanten übereinander, bekommen sie einen Bogen
- es können nur valide Kanten ausgewählt werden (nur DFGArcs und nur, wenn sie zu einem gemeinsamen DFG gehören), ansonsten erscheint eine Fehlermeldung

Was ich noch nicht testen konnte, ist eine Darstellung eines DFG, wenn zwei Aktivitäten übereinander liegen und mit einem "Doppelpfleil" verbunden wären. Ich hatte hier noch keine Kombination gefunden.