### PR TITLE
SCRUM-57-Zuruecksetzen-des-Event-Logs-auf-Ursprungszustand-ermoeglichen

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@angular/platform-browser-dynamic": "^18.2.6",
         "@angular/router": "^18.2.6",
         "fast-xml-parser": "^4.5.1",
+        "lodash": "^4.17.21",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.0"
@@ -36,6 +37,7 @@
         "@types/jasmine": "~4.3.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
+        "@types/lodash": "^4.17.13",
         "jasmine-core": "~4.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       fast-xml-parser:
         specifier: ^4.5.1
         version: 4.5.1
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       rxjs:
         specifier: ~7.8.0
         version: 7.8.1
@@ -69,6 +72,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.10.2
+      '@types/lodash':
+        specifier: ^4.17.13
+        version: 4.17.13
       jasmine-core:
         specifier: ~4.6.0
         version: 4.6.1
@@ -1694,6 +1700,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash@4.17.13':
+    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -6175,6 +6184,8 @@ snapshots:
       pretty-format: 29.7.0
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/lodash@4.17.13': {}
 
   '@types/mime@1.3.5': {}
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -20,6 +20,15 @@
             <mat-icon>playlist_add</mat-icon>
             Input Event Log
         </button>
+        <button
+            mat-fab
+            extended
+            [disabled]="undoButtonIsDisabled"
+            (click)="undoLastUpdate()"
+        >
+            <mat-icon>undo</mat-icon>
+            Undo Last Split
+        </button>
     </div>
     <hr />
     <div class="flexRowAlignSpaceEvenlyStart">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -62,12 +62,20 @@ export class AppComponent {
     activityOncePerTraceExecution(): void {
         this._fallThroughHandlingService.executeActivityOncePerTraceFallThrough();
     }
-    
+
     flowerExecution() {
         this._fallThroughHandlingService.executeFlowerFallThrough();
     }
-    
+
+    undoLastUpdate() {
+        this._petriNetManagementService.updateToPreviousPetriNet();
+    }
+
     get actionButtonsAreDisabled(): boolean {
         return !this._petriNetManagementService.isModifiable;
+    }
+
+    get undoButtonIsDisabled(): boolean {
+        return this._petriNetManagementService.isInputPetriNet;
     }
 }

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -4,29 +4,26 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { Dfg } from '../classes/dfg/dfg';
 import { ShowFeedbackService } from './show-feedback.service';
 import { CollectArcsService } from './collect-arcs.service';
+import _ from 'lodash';
 
 @Injectable({
     providedIn: 'root',
 })
 export class PetriNetManagementService {
     private _petriNet: PetriNet = new PetriNet();
+    private _previousPetriNets: PetriNet[] = [];
     private _isModifiable: boolean = false;
+    private _isInputPetriNet: boolean = true;
 
     private _petriNet$: BehaviorSubject<PetriNet> =
         new BehaviorSubject<PetriNet>(this._petriNet);
-
-    get petriNet$(): Observable<PetriNet> {
-        return this._petriNet$.asObservable();
-    }
-
-    get isModifiable(): boolean {
-        return this._isModifiable;
-    }
 
     constructor(private _showFeedbackService: ShowFeedbackService) {}
 
     public initialize(dfg: Dfg): void {
         this._petriNet = new PetriNet(dfg);
+        this._previousPetriNets = [];
+        this._isInputPetriNet = true;
         if (this._petriNet.isBasicPetriNet()) {
             this._isModifiable = false;
             this._showFeedbackService.showMessage(
@@ -44,6 +41,7 @@ export class PetriNetManagementService {
         subDFG1: Dfg,
         subDFG2: Dfg,
     ): void {
+        this.addPreviousPetriNet();
         this._petriNet.updateByExclusiveCut(originDFG, subDFG1, subDFG2);
         this.updatePn();
     }
@@ -53,6 +51,7 @@ export class PetriNetManagementService {
         subDFG1: Dfg,
         subDFG2: Dfg,
     ): void {
+        this.addPreviousPetriNet();
         this._petriNet.updateBySequenceCut(originDFG, subDFG1, subDFG2);
         this.updatePn();
     }
@@ -62,30 +61,64 @@ export class PetriNetManagementService {
         subDFG1: Dfg,
         subDFG2: Dfg,
     ): void {
+        this.addPreviousPetriNet();
         this._petriNet.updateByParallelCut(originDFG, subDFG1, subDFG2);
         this.updatePn();
     }
 
     public updatePnByLoopCut(originDFG: Dfg, subDFG1: Dfg, subDFG2: Dfg): void {
+        this.addPreviousPetriNet();
         this._petriNet.updateByLoopCut(originDFG, subDFG1, subDFG2);
         this.updatePn();
     }
 
     public updatePnByFlowerFallThrough(dfg: Dfg, subDFGs: Dfg[]) {
+        this.addPreviousPetriNet();
         this._petriNet.updateByFlowerFallThrough(dfg, subDFGs);
         this.updatePn();
+    }
+
+    updateToPreviousPetriNet(): void {
+        const prevPetriNet: PetriNet | undefined =
+            this._previousPetriNets.pop();
+        if (prevPetriNet !== undefined) {
+            this._petriNet = prevPetriNet;
+            this.updatePn();
+        }
     }
 
     private updatePn(): void {
         if (this._petriNet.isBasicPetriNet()) {
             this._isModifiable = false;
             this._showFeedbackService.showMessage(
-                'The input event log is completely splitted.',
+                'The event log is completely splitted.',
                 false,
             );
         } else {
             this._isModifiable = true;
         }
+        if (this._previousPetriNets.length === 0) {
+            this._isInputPetriNet = true;
+        } else {
+            this._isInputPetriNet = false;
+        }
         this._petriNet$.next(this._petriNet);
+    }
+
+    private addPreviousPetriNet(): void {
+        const petriNetCopy: PetriNet = _.cloneDeep(this._petriNet);
+        this._previousPetriNets.push(petriNetCopy);
+    }
+
+    get petriNet$(): Observable<PetriNet> {
+        return this._petriNet$.asObservable();
+    }
+
+    get isModifiable(): boolean {
+        return this._isModifiable;
+    }
+
+    get isInputPetriNet(): boolean {
+        return this._isInputPetriNet;
     }
 }


### PR DESCRIPTION
Über undo-Button kann das aktuelle Eventlog solange zurückgesetzt werden, bis wieder der DFG des initialien Eventlogs angezeigt wird.