### PR TITLE
SCRUM-14-Kanten-auswaehlbar-machen-Multiselect-3

### DIFF
--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -53,6 +53,7 @@ import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
             (click)="onLineClick($event, arc)"
         ></svg:path>
         <svg:path
+            [attr.class]="'visiblePath'"
             [attr.d]="pathForLine(arc)"
             [attr.stroke]="'black'"
             [attr.stroke-width]="width"

--- a/src/app/services/collect-arcs.service.ts
+++ b/src/app/services/collect-arcs.service.ts
@@ -47,11 +47,13 @@ export class CollectArcsService {
         )[0] as SVGSVGElement;
 
         if (svg) {
-            const lines = svg.querySelectorAll('line');
-            lines.forEach((line) => {
-                line.classList.remove('active');
-                line.classList.remove('hovered');
-                line.setAttribute('marker-end', 'url(#arrowhead)');
+            const paths = svg.querySelectorAll('path');
+            paths.forEach((path) => {
+                path.classList.remove('active');
+                path.classList.remove('hovered');
+                if (path.classList.contains('visiblePath')) {
+                    path.setAttribute('marker-end', 'url(#arrowhead)');
+                }
             });
         }
     }


### PR DESCRIPTION
Nach Anpassung der line-Elemente zu path-Elementen hat das Reset der Kanten nicht mehr funktioniert. Das habe ich mit diesem PR noch nachgezogen.