### PR TITLE
SCRUM-80-Ausgewaehlte-Kanten-bei-falschem-Cut-ausgewaehlt-lassen

### DIFF
--- a/src/app/components/cut-execution/cut-execution.component.ts
+++ b/src/app/components/cut-execution/cut-execution.component.ts
@@ -62,7 +62,6 @@ export class CutExecutionComponent implements OnInit {
                 selectedValue,
             );
             this.resetRadioSelection();
-            this._collectArcsService.resetCollectedArcs();
         } else if (!selectedValue && this._collectArcsService.currentDFG) {
             this._feedbackService.showMessage(
                 'No cut selected via radio buttons!',


### PR DESCRIPTION
Aufruf zum Löschen der ausgewählten Kanten beim Execute gelöscht.