### PR TITLE
SCRUM-87-Cut-Logik-ueberpruefen-2

### DIFF
--- a/src/app/classes/dfg/arcs.ts
+++ b/src/app/classes/dfg/arcs.ts
@@ -155,12 +155,10 @@ export class Arcs {
         return partition.addAll(reachableActivities);
     }
     /* 
-    return all arcs from this Arcs, except that ones contained in cuttedArcs
+    return all arcs from this Arcs, except that ones contained in arcs
      */
-    private removeArcsBy(cuttedArcs: Arcs): Arcs {
-        return new Arcs(
-            this.arcs.filter((arc) => !cuttedArcs.containsArc(arc)),
-        );
+    removeArcsBy(arcs: Arcs): Arcs {
+        return new Arcs(this.arcs.filter((arc) => !arcs.containsArc(arc)));
     }
 
     addArc(arc: DfgArc): Arcs {

--- a/src/app/classes/dfg/cuts.spec.ts
+++ b/src/app/classes/dfg/cuts.spec.ts
@@ -1,4 +1,4 @@
-import { EventLog } from '../event-log';
+import { CutType } from 'src/app/components/cut-execution/cut-execution.component';
 import { Activities } from './activities';
 import { Arcs, DfgArc } from './arcs';
 import { ExclusiveCut, LoopCut, ParallelCut, SequenceCut } from './cut';
@@ -22,7 +22,7 @@ describe('A Dfg', () => {
         const a1: Activities = partitions[0];
         const a2: Activities = partitions[1];
 
-        const result: boolean = sut.canBeCutIn(a1, a2).result;
+        const result: boolean = sut.canBeCutIn(a1, a2).cutIsPossible;
 
         expect(result).toBeFalse();
     });
@@ -44,7 +44,7 @@ describe('A Dfg', () => {
         const a1: Activities = partitions[0];
         const a2: Activities = partitions[1];
 
-        const result: boolean = sut.canBeCutIn(a1, a2).result;
+        const result: boolean = sut.canBeCutIn(a1, a2).cutIsPossible;
 
         expect(result).toBeFalse();
     });
@@ -68,7 +68,7 @@ describe('A Dfg', () => {
         const a1: Activities = partitions[0];
         const a2: Activities = partitions[1];
 
-        const result: boolean = sut.canBeCutIn(a1, a2).result;
+        const result: boolean = sut.canBeCutIn(a1, a2).cutIsPossible;
 
         expect(result).toBeFalse();
     });
@@ -88,7 +88,7 @@ describe('A Dfg', () => {
         const a2: Activities = partitions[1];
         a2.createActivity('C');
 
-        const result: boolean = sut.canBeCutIn(a1, a2).result;
+        const result: boolean = sut.canBeCutIn(a1, a2).cutIsPossible;
 
         expect(result).toBeFalse();
     });
@@ -108,7 +108,7 @@ describe('A Dfg', () => {
         const a1: Activities = partitions[0];
         const a2: Activities = partitions[1];
 
-        const result: boolean = sut.canBeCutIn(a1, a2).result;
+        const result: boolean = sut.canBeCutIn(a1, a2).cutIsPossible;
 
         expect(result).toBeFalse();
     });
@@ -134,14 +134,18 @@ describe('A Dfg', () => {
                 .addArc(sut.getArc('play', 'C'))
                 .addArc(sut.getArc('C', 'stop'));
 
-            const partitions: Activities[] =
-                sut.calculatePartitions(cuttedArcs);
-            const a1: Activities = partitions[0];
-            const a2: Activities = partitions[1];
+            const result = sut.canBeCutBy(cuttedArcs, CutType.ExclusiveCut);
+            const selectedCut = result[0].cutIsPossible;
+            let selectedArcsIsMinimum = true;
+            for (let i = 1; i < result.length; i++) {
+                if (result[i].cutIsPossible) {
+                    selectedArcsIsMinimum = false;
+                    break;
+                }
+            }
 
-            const result: boolean = sut.canBeCutIn(a1, a2).result;
-
-            expect(result).toBeTrue();
+            expect(selectedCut).toBeTrue();
+            expect(selectedArcsIsMinimum).toBeTrue();
         },
     );
 
@@ -171,14 +175,18 @@ describe('A Dfg', () => {
                 .addArc(sut.getArc('A', 'C'))
                 .addArc(sut.getArc('B', 'D'));
 
-            const partitions: Activities[] =
-                sut.calculatePartitions(cuttedArcs);
-            const a1: Activities = partitions[0];
-            const a2: Activities = partitions[1];
+            const result = sut.canBeCutBy(cuttedArcs, CutType.SequenceCut);
+            const selectedCut = result[0].cutIsPossible;
+            let selectedArcsIsMinimum = true;
+            for (let i = 1; i < result.length; i++) {
+                if (result[i].cutIsPossible) {
+                    selectedArcsIsMinimum = false;
+                    break;
+                }
+            }
 
-            const result: boolean = sut.canBeCutIn(a1, a2).result;
-
-            expect(result).toBeTrue();
+            expect(selectedCut).toBeTrue();
+            expect(selectedArcsIsMinimum).toBeTrue();
         },
     );
 
@@ -214,14 +222,18 @@ describe('A Dfg', () => {
                 .addArc(sut.getArc('C', 'B'))
                 .addArc(sut.getArc('B', 'C'));
 
-            const partitions: Activities[] =
-                sut.calculatePartitions(cuttedArcs);
-            const a1: Activities = partitions[0];
-            const a2: Activities = partitions[1];
+            const result = sut.canBeCutBy(cuttedArcs, CutType.ParallelCut);
+            const selectedCut = result[0].cutIsPossible;
+            let selectedArcsIsMinimum = true;
+            for (let i = 1; i < result.length; i++) {
+                if (result[i].cutIsPossible) {
+                    selectedArcsIsMinimum = false;
+                    break;
+                }
+            }
 
-            const result: boolean = sut.canBeCutIn(a1, a2).result;
-
-            expect(result).toBeTrue();
+            expect(selectedCut).toBeTrue();
+            expect(selectedArcsIsMinimum).toBeTrue();
         },
     );
 
@@ -251,14 +263,18 @@ describe('A Dfg', () => {
                 .addArc(sut.getArc('C', 'A'))
                 .addArc(sut.getArc('B', 'C'));
 
-            const partitions: Activities[] =
-                sut.calculatePartitions(cuttedArcs);
-            const a1: Activities = partitions[0];
-            const a2: Activities = partitions[1];
+            const result = sut.canBeCutBy(cuttedArcs, CutType.ExclusiveCut);
+            const selectedCut = result[0].cutIsPossible;
+            let selectedArcsIsMinimum = true;
+            for (let i = 1; i < result.length; i++) {
+                if (result[i].cutIsPossible) {
+                    selectedArcsIsMinimum = false;
+                    break;
+                }
+            }
 
-            const result: boolean = sut.canBeCutIn(a1, a2).result;
-
-            expect(result).toBeTrue();
+            expect(selectedCut).toBeTrue();
+            expect(selectedArcsIsMinimum).toBeTrue();
         },
     );
 });
@@ -1029,5 +1045,199 @@ describe('A LoopCut', () => {
         const result: boolean = sut.isPossible(activities, arcs);
 
         expect(result).toBeFalse();
+    });
+});
+
+describe('Complete event Log split: x y x + a b c + a c b', () => {
+    it('can not be exclusive-cut if unnecessary arcs are selected', () => {
+        const sut: Dfg = new DfgBuilder()
+            .createActivity('X')
+            .createActivity('Y')
+            .createActivity('A')
+            .createActivity('B')
+            .createActivity('C')
+            .addFromPlayArc('X')
+            .addArc('X', 'Y')
+            .addArc('Y', 'X')
+            .addToStopArc('X')
+            .addFromPlayArc('A')
+            .addArc('A', 'B')
+            .addArc('B', 'C')
+            .addToStopArc('C')
+            .addArc('A', 'C')
+            .addArc('C', 'B')
+            .addToStopArc('B')
+            .build();
+        const cuttedArcs: Arcs = new Arcs()
+            .addArc(sut.getArc('A', 'C'))
+            .addArc(sut.getArc('B', 'C'))
+            .addArc(sut.getArc('C', 'B'))
+            .addArc(sut.getArc('play', 'X'))
+            .addArc(sut.getArc('X', 'stop'));
+        const result = sut.canBeCutBy(cuttedArcs, CutType.ExclusiveCut);
+
+        const selectedCut = result[0].cutIsPossible;
+        let selectedArcsIsMinimum = true;
+        for (let i = 1; i < result.length; i++) {
+            if (result[i].cutIsPossible) {
+                selectedArcsIsMinimum = false;
+                break;
+            }
+        }
+        expect(selectedCut).toBeTrue();
+        expect(selectedArcsIsMinimum).toBeFalse();
+    });
+
+    it('can be exclusive-cut if no unnecessary arcs are selected', () => {
+        const sut: Dfg = new DfgBuilder()
+            .createActivity('X')
+            .createActivity('Y')
+            .createActivity('A')
+            .createActivity('B')
+            .createActivity('C')
+            .addFromPlayArc('X')
+            .addArc('X', 'Y')
+            .addArc('Y', 'X')
+            .addToStopArc('X')
+            .addFromPlayArc('A')
+            .addArc('A', 'B')
+            .addArc('B', 'C')
+            .addToStopArc('C')
+            .addArc('A', 'C')
+            .addArc('C', 'B')
+            .addToStopArc('B')
+            .build();
+        const cuttedArcs: Arcs = new Arcs()
+            .addArc(sut.getArc('play', 'X'))
+            .addArc(sut.getArc('X', 'stop'));
+
+        const result = sut.canBeCutBy(cuttedArcs, CutType.ExclusiveCut);
+        const selectedCut: boolean = result[0].cutIsPossible;
+        let selectedArcsIsMinimum = true;
+        for (let i = 1; i < result.length; i++) {
+            if (result[i].cutIsPossible) {
+                selectedArcsIsMinimum = false;
+                break;
+            }
+        }
+        expect(selectedCut).toBeTrue();
+        expect(selectedArcsIsMinimum).toBeTrue();
+    });
+
+    it('can not be sequence-cut if unnecessary arcs are selected', () => {
+        const sut: Dfg = new DfgBuilder()
+            .createActivity('A')
+            .createActivity('B')
+            .createActivity('C')
+            .addFromPlayArc('A')
+            .addArc('A', 'B')
+            .addArc('B', 'C')
+            .addToStopArc('C')
+            .addArc('A', 'C')
+            .addArc('C', 'B')
+            .addToStopArc('B')
+            .build();
+        const cuttedArcs: Arcs = new Arcs()
+            .addArc(sut.getArc('A', 'B'))
+            .addArc(sut.getArc('A', 'C'))
+            .addArc(sut.getArc('C', 'stop'));
+
+        const result = sut.canBeCutBy(cuttedArcs, CutType.SequenceCut);
+        const selectedCut = result[0].cutIsPossible;
+        let selectedArcsIsMinimum = true;
+        for (let i = 1; i < result.length; i++) {
+            if (result[i].cutIsPossible) {
+                selectedArcsIsMinimum = false;
+                break;
+            }
+        }
+        expect(selectedCut).toBeTrue();
+        expect(selectedArcsIsMinimum).toBeFalse();
+    });
+
+    it('can be sequence-cut if no unnecessary arcs are selected', () => {
+        const sut: Dfg = new DfgBuilder()
+            .createActivity('A')
+            .createActivity('B')
+            .createActivity('C')
+            .addFromPlayArc('A')
+            .addArc('A', 'B')
+            .addArc('B', 'C')
+            .addToStopArc('C')
+            .addArc('A', 'C')
+            .addArc('C', 'B')
+            .addToStopArc('B')
+            .build();
+        const cuttedArcs: Arcs = new Arcs()
+            .addArc(sut.getArc('A', 'B'))
+            .addArc(sut.getArc('A', 'C'));
+
+        const result = sut.canBeCutBy(cuttedArcs, CutType.SequenceCut);
+        const selectedCut = result[0].cutIsPossible;
+        let selectedArcsIsMinimum = true;
+        for (let i = 1; i < result.length; i++) {
+            if (result[i].cutIsPossible) {
+                selectedArcsIsMinimum = false;
+                break;
+            }
+        }
+        expect(selectedCut).toBeTrue();
+        expect(selectedArcsIsMinimum).toBeTrue();
+    });
+
+    it('can be parallel-cut if no unnecessary arcs are selected', () => {
+        const sut: Dfg = new DfgBuilder()
+            .createActivity('B')
+            .createActivity('C')
+            .addFromPlayArc('B')
+            .addArc('B', 'C')
+            .addToStopArc('C')
+            .addFromPlayArc('C')
+            .addArc('C', 'B')
+            .addToStopArc('B')
+            .build();
+        const cuttedArcs: Arcs = new Arcs()
+            .addArc(sut.getArc('play', 'B'))
+            .addArc(sut.getArc('B', 'stop'))
+            .addArc(sut.getArc('B', 'C'))
+            .addArc(sut.getArc('C', 'B'));
+
+        const result = sut.canBeCutBy(cuttedArcs, CutType.ParallelCut);
+        const selectedCut = result[0].cutIsPossible;
+        let selectedArcsIsMinimum = true;
+        for (let i = 1; i < result.length; i++) {
+            if (result[i].cutIsPossible) {
+                selectedArcsIsMinimum = false;
+                break;
+            }
+        }
+        expect(selectedCut).toBeTrue();
+        expect(selectedArcsIsMinimum).toBeTrue();
+    });
+
+    it('can be loop-cut if no unnecessary arcs are selected', () => {
+        const sut: Dfg = new DfgBuilder()
+            .createActivity('X')
+            .createActivity('Y')
+            .addFromPlayArc('X')
+            .addArc('X', 'Y')
+            .addArc('Y', 'X')
+            .addToStopArc('X')
+            .build();
+        const cuttedArcs: Arcs = new Arcs()
+            .addArc(sut.getArc('X', 'Y'))
+            .addArc(sut.getArc('Y', 'X'));
+
+        const result = sut.canBeCutBy(cuttedArcs, CutType.LoopCut);
+        const selectedCut = result[0].cutIsPossible;
+        let selectedArcsIsMinimum = true;
+        for (let i = 1; i < result.length; i++) {
+            if (result[i].cutIsPossible) {
+                selectedArcsIsMinimum = false;
+                break;
+            }
+        }
+        expect(selectedCut).toBeTrue();
+        expect(selectedArcsIsMinimum).toBeTrue();
     });
 });

--- a/src/app/classes/dfg/dfg.ts
+++ b/src/app/classes/dfg/dfg.ts
@@ -20,31 +20,113 @@ export class Dfg implements PetriNetTransition {
         this.id = 'DFG' + ++Dfg.idCount;
     }
 
+    canBeCutBy(
+        selectedArcs: Arcs,
+        cutType: CutType,
+    ): {
+        cutIsPossible: boolean;
+        matchingCut: CutType | null;
+        a1: Activities;
+        a2: Activities;
+    }[] {
+        console.log('methode selected: ' + selectedArcs.getArcs().length);
+        const results = [];
+        let partitionsCount = 0;
+        const partitions: Activities[] = this.calculatePartitions(selectedArcs);
+        const a1: Activities = partitions[0];
+        const a2: Activities = partitions[1];
+        const selectedCut = this.canBeCutIn(a1, a2);
+        results[partitionsCount++] = selectedCut;
+        if (!selectedCut.cutIsPossible || selectedCut.matchingCut !== cutType) {
+            return results;
+        }
+        for (const arc of selectedArcs.getArcs()) {
+            const reducedArcs: Arcs = selectedArcs.removeArcsBy(
+                new Arcs([arc]),
+            );
+            console.log('reduced length ' + reducedArcs.getArcs().length);
+            const partitions: Activities[] =
+                this.calculatePartitions(reducedArcs);
+            const reducedA1: Activities = partitions[0];
+            const reducedA2: Activities = partitions[1];
+            results[partitionsCount++] = this.canBeCutIn(reducedA1, reducedA2);
+        }
+        console.log('methode result: ' + results.length);
+        return results;
+    }
+
     canBeCutIn(
         a1: Activities,
         a2: Activities,
-    ): { result: boolean; matchingcut: CutType | null } {
+    ): {
+        cutIsPossible: boolean;
+        matchingCut: CutType | null;
+        a1: Activities;
+        a2: Activities;
+    } {
         if (new ExclusiveCut(a1, a2).isPossible(this.activities, this.arcs)) {
-            return { result: true, matchingcut: CutType.ExclusiveCut };
+            return {
+                cutIsPossible: true,
+                matchingCut: CutType.ExclusiveCut,
+                a1,
+                a2,
+            };
         }
         if (new SequenceCut(a1, a2).isPossible(this.activities, this.arcs)) {
-            return { result: true, matchingcut: CutType.SequenceCut };
+            return {
+                cutIsPossible: true,
+                matchingCut: CutType.SequenceCut,
+                a1,
+                a2,
+            };
         }
         if (new ParallelCut(a1, a2).isPossible(this.activities, this.arcs)) {
-            return { result: true, matchingcut: CutType.ParallelCut };
+            return {
+                cutIsPossible: true,
+                matchingCut: CutType.ParallelCut,
+                a1,
+                a2,
+            };
         }
         if (new LoopCut(a1, a2).isPossible(this.activities, this.arcs)) {
-            return { result: true, matchingcut: CutType.LoopCut };
+            return {
+                cutIsPossible: true,
+                matchingCut: CutType.LoopCut,
+                a1,
+                a2,
+            };
         }
 
-        return { result: false, matchingcut: null };
+        return { cutIsPossible: false, matchingCut: null, a1, a2 };
+    }
+
+    canBeCutByAnyPartitions(): boolean {
+        const copy: Activities = new Activities()
+            .addAll(this.activities)
+            .removePlayAndStop();
+        for (let mask = 1; mask < 1 << copy.getLength(); mask++) {
+            const sub1: Activities = new Activities();
+            const sub2: Activities = new Activities();
+            for (let i = 0; i < copy.getLength(); i++) {
+                const activity: Activity = copy.getActivityByIndex(i);
+                if ((mask & (1 << i)) !== 0) {
+                    sub1.addActivity(activity);
+                } else {
+                    sub2.addActivity(activity);
+                }
+            }
+            if (this.canBeCutIn(sub1, sub2).cutIsPossible) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /* 
-    cuttedArcs are the arcs that are choosen by user for cut, the return
-    partitions contain activities from this DFG divided into two partitions,
-    each one without play and stop and without any assurance for completeness
-    */
+        cuttedArcs are the arcs that are choosen by user for cut, the return
+        partitions contain activities from this DFG divided into two partitions,
+        each one without play and stop and without any assurance for completeness
+        */
     calculatePartitions(cuttedArcs: Arcs): Activities[] {
         const a1: Activities =
             this.arcs.calculateActivityPartitionByActivitiesReachableFromPlay(
@@ -64,28 +146,6 @@ export class Dfg implements PetriNetTransition {
             )
             .removePlayAndStop();
         return [a1, a2];
-    }
-
-    canBeCutByAnyPartitions(): boolean {
-        const copy: Activities = new Activities()
-            .addAll(this.activities)
-            .removePlayAndStop();
-        for (let mask = 1; mask < 1 << copy.getLength(); mask++) {
-            const sub1: Activities = new Activities();
-            const sub2: Activities = new Activities();
-            for (let i = 0; i < copy.getLength(); i++) {
-                const activity: Activity = copy.getActivityByIndex(i);
-                if ((mask & (1 << i)) !== 0) {
-                    sub1.addActivity(activity);
-                } else {
-                    sub2.addActivity(activity);
-                }
-            }
-            if (this.canBeCutIn(sub1, sub2).result) {
-                return true;
-            }
-        }
-        return false;
     }
 
     isBaseCase(): boolean {

--- a/src/app/services/execute-cut.service.ts
+++ b/src/app/services/execute-cut.service.ts
@@ -7,27 +7,32 @@ import { EventLog } from '../classes/event-log';
 import { PetriNetManagementService } from './petri-net-management.service';
 import { CutType } from '../components/cut-execution/cut-execution.component';
 import { ShowFeedbackService } from './show-feedback.service';
+import { PetriNet } from '../classes/petrinet/petri-net';
 
 @Injectable({
     providedIn: 'root',
 })
 export class ExecuteCutService {
+    private _petriNet!: PetriNet;
+
     constructor(
         private _petriNetManagementService: PetriNetManagementService,
         private _calculateDfgService: CalculateDfgService,
         private _feedbackService: ShowFeedbackService,
-    ) {}
+    ) {
+        this._petriNetManagementService.petriNet$.subscribe((pn) => {
+            this._petriNet = pn;
+        });
+    }
 
     public execute(dfg: Dfg, selectedArcs: Arcs, selectedCut: CutType): void {
-        const partitions: Activities[] = dfg.calculatePartitions(selectedArcs);
-        const a1: Activities = partitions[0];
-        const a2: Activities = partitions[1];
-
-        const isValidCut: boolean =
-            dfg.canBeCutIn(a1, a2).result &&
-            dfg.canBeCutIn(a1, a2).matchingcut === selectedCut;
-
-        if (!isValidCut) {
+        const cutFeasibilityResults: {
+            cutIsPossible: boolean;
+            matchingCut: CutType | null;
+            a1: Activities;
+            a2: Activities;
+        }[] = dfg.canBeCutBy(selectedArcs, selectedCut);
+        if (cutFeasibilityResults.length === 1) {
             this._feedbackService.showMessage(
                 'Not a valid Cut! Please try again!',
                 true,
@@ -35,13 +40,30 @@ export class ExecuteCutService {
             );
             return;
         }
+        const validCut: {
+            cutIsPossible: boolean;
+            matchingCut: CutType | null;
+            a1: Activities;
+            a2: Activities;
+        } = cutFeasibilityResults[0];
+        for (let i = 1; i < cutFeasibilityResults.length; i++) {
+            if (
+                cutFeasibilityResults[i].cutIsPossible &&
+                cutFeasibilityResults[i].matchingCut === selectedCut
+            ) {
+                this._feedbackService.showMessage(
+                    'Too many arcs selected. Please select minimum amount of required arcs.',
+                    true,
+                );
+                return;
+            }
+        }
 
         let subEventLogs: [EventLog, EventLog];
         let subDfgs: [Dfg, Dfg];
-
         switch (selectedCut) {
             case CutType.ExclusiveCut:
-                subEventLogs = dfg.eventLog.splitByExclusiveCut(a1);
+                subEventLogs = dfg.eventLog.splitByExclusiveCut(validCut.a1);
                 subDfgs = this.createSubDfgs(subEventLogs);
                 this._petriNetManagementService.updatePnByExclusiveCut(
                     dfg,
@@ -50,7 +72,7 @@ export class ExecuteCutService {
                 );
                 break;
             case CutType.SequenceCut:
-                subEventLogs = dfg.eventLog.splitBySequenceCut(a2);
+                subEventLogs = dfg.eventLog.splitBySequenceCut(validCut.a2);
                 subDfgs = this.createSubDfgs(subEventLogs);
                 this._petriNetManagementService.updatePnBySequenceCut(
                     dfg,
@@ -59,7 +81,7 @@ export class ExecuteCutService {
                 );
                 break;
             case CutType.ParallelCut:
-                subEventLogs = dfg.eventLog.splitByParallelCut(a1);
+                subEventLogs = dfg.eventLog.splitByParallelCut(validCut.a1);
                 subDfgs = this.createSubDfgs(subEventLogs);
                 this._petriNetManagementService.updatePnByParallelCut(
                     dfg,
@@ -68,7 +90,10 @@ export class ExecuteCutService {
                 );
                 break;
             case CutType.LoopCut:
-                subEventLogs = dfg.eventLog.splitByLoopCut(a1, a2);
+                subEventLogs = dfg.eventLog.splitByLoopCut(
+                    validCut.a1,
+                    validCut.a2,
+                );
                 subDfgs = this.createSubDfgs(subEventLogs);
                 this._petriNetManagementService.updatePnByLoopCut(
                     dfg,
@@ -77,12 +102,11 @@ export class ExecuteCutService {
                 );
                 break;
         }
-
-        this._feedbackService.showMessage(
-            'Cut was executed successfully! ' + '(' + selectedCut + ')',
-            false,
-        );
-        this._feedbackService.showMessage('The petri net was updated.', false);
+        if (this._petriNet.isBasicPetriNet()) {
+            this._petriNetManagementService.showEventLogCompletelySplitted();
+            return;
+        }
+        this._feedbackService.showMessage(selectedCut + ' executed', false);
     }
 
     private createSubDfgs(eventLogs: [EventLog, EventLog]): [Dfg, Dfg] {

--- a/src/app/services/fall-through-handling.service.ts
+++ b/src/app/services/fall-through-handling.service.ts
@@ -78,6 +78,14 @@ export class FallThroughHandlingService {
                         subDFGs[0],
                         subDFGs[1],
                     );
+                    if (this._petriNet.isBasicPetriNet()) {
+                        this._petriNetManagementService.showEventLogCompletelySplitted();
+                        return;
+                    }
+                    this._showFeedbackService.showMessage(
+                        'Activity-Once-Per-Trace Fall-Through executed',
+                        false,
+                    );
                     return;
                 }
             } catch {
@@ -112,8 +120,16 @@ export class FallThroughHandlingService {
                 dfg,
                 subDFGs,
             );
-            return;
+            if (this._petriNet.isBasicPetriNet()) {
+                this._petriNetManagementService.showEventLogCompletelySplitted();
+                return;
+            }
         }
+        this._showFeedbackService.showMessage(
+            'Flower-Model Fall-Through executed',
+            false,
+        );
+        return;
     }
 
     processActivityClick(activityName: string) {

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -3,7 +3,6 @@ import { PetriNet } from '../classes/petrinet/petri-net';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Dfg } from '../classes/dfg/dfg';
 import { ShowFeedbackService } from './show-feedback.service';
-import { CollectArcsService } from './collect-arcs.service';
 import _ from 'lodash';
 
 @Injectable({
@@ -90,10 +89,6 @@ export class PetriNetManagementService {
     private updatePn(): void {
         if (this._petriNet.isBasicPetriNet()) {
             this._isModifiable = false;
-            this._showFeedbackService.showMessage(
-                'The event log is completely splitted.',
-                false,
-            );
         } else {
             this._isModifiable = true;
         }
@@ -108,6 +103,13 @@ export class PetriNetManagementService {
     private addPreviousPetriNet(): void {
         const petriNetCopy: PetriNet = _.cloneDeep(this._petriNet);
         this._previousPetriNets.push(petriNetCopy);
+    }
+
+    showEventLogCompletelySplitted(): void {
+        this._showFeedbackService.showMessage(
+            'The event log is completely splitted.',
+            false,
+        );
     }
 
     get petriNet$(): Observable<PetriNet> {


### PR DESCRIPTION
In dieser Umsetzung werden nur noch eindeutige Cuts zugelassen. Also solche, in denen keine unnötigen Kanten ausgwählt zusätzlich ausgewähltt sind. Damit ist immer genau zu erkennen welche Kanten den Cut darstellen