### PR TITLE
SCRUM-45-Knoten-und-Kanten-sollen-ziehbar-verschiebbar-sein

### DIFF
--- a/src/app/classes/graph.ts
+++ b/src/app/classes/graph.ts
@@ -53,6 +53,14 @@ export abstract class Node {
         return this._y;
     }
 
+    set x(x: number) {
+        this._x = x;
+    }
+
+    set y(y: number) {
+        this._y = y;
+    }
+
     equals(other: Node): boolean {
         return (
             this._id === other._id &&
@@ -85,7 +93,20 @@ export abstract class Node {
 // This dummy is used for box intersection calculation
 export class DummyNode extends Node {}
 
-export class ActivityNode extends Node {}
+export class ActivityNode extends Node {
+    constructor(
+        _id: string,
+        _x: number,
+        _y: number,
+        private _dfgId: string,
+    ) {
+        super(_id, _x, _y);
+    }
+
+    get dfg(): string {
+        return this._dfgId;
+    }
+}
 
 export class PlaceNode extends Node {}
 
@@ -111,7 +132,7 @@ export class BoxNode extends Node {
         _y: number,
         private _width: number,
         private _height: number,
-        private _eventLog: string
+        private _eventLog: string,
     ) {
         super(_id, _x, _y);
     }

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -5,7 +5,6 @@ import { FallThroughHandlingService } from 'src/app/services/fall-through-handli
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { Subscription } from 'rxjs';
 import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
-import { CollectArcsService } from 'src/app/services/collect-arcs.service';
 
 @Component({
     selector: 'svg:g[app-drawing-activity]',
@@ -55,7 +54,6 @@ export class DrawingActivityComponent {
     constructor(
         private _collectSelectedElementsService: CollectSelectedElementsService,
         private _positionForActivitiesService: PositionForActivitiesService,
-        private _collectArcsService: CollectArcsService,
     ) {}
 
     readonly width: number = environment.drawingElements.activities.height;
@@ -213,7 +211,7 @@ export class DrawingActivityComponent {
                 this.activity.y,
             );
             this.mouseClicked = false;
-            this._collectArcsService.resetCollectedArcs();
+            this._collectSelectedElementsService.resetSelectedArcs();
         }
     }
 

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
-import { Activity } from '../models';
+import { Activity, Box } from '../models';
 import { environment } from 'src/environments/environment';
 import { FallThroughHandlingService } from 'src/app/services/fall-through-handling.service';
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
+import { Subscription } from 'rxjs';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
 
 @Component({
     selector: 'svg:g[app-drawing-activity]',
@@ -17,7 +19,12 @@ import { CollectSelectedElementsService } from 'src/app/services/collect-selecte
             [attr.stroke]="strokeColor"
             [attr.stroke-opacity]="strokeOpacity"
             [attr.stroke-width]="strokeWidth"
+            [classList]="'draggable confine'"
             (click)="onActivityClick($event, activity)"
+            (mousedown)="startDrag($event)"
+            (mousemove)="drag($event)"
+            (mouseup)="endDrag($event)"
+            (mouseleave)="endDrag($event)"
         />
         <svg:text
             [attr.x]="activity.x"
@@ -36,6 +43,9 @@ import { CollectSelectedElementsService } from 'src/app/services/collect-selecte
             stroke-width: 5;
             stroke: #085c5c;
         }
+        .draggable {
+            cursor: move;
+        }
     `,
 })
 export class DrawingActivityComponent {
@@ -43,6 +53,7 @@ export class DrawingActivityComponent {
 
     constructor(
         private _collectSelectedElementsService: CollectSelectedElementsService,
+        private _positionForActivitiesService: PositionForActivitiesService,
     ) {}
 
     readonly width: number = environment.drawingElements.activities.height;
@@ -58,6 +69,42 @@ export class DrawingActivityComponent {
         environment.drawingElements.activities.strokeOpacity;
     readonly strokeWidth: number =
         environment.drawingElements.activities.strokeWidth;
+
+    private _sub: Subscription | undefined;
+
+    elementSelected: any;
+    offset: any;
+    transform: any;
+    mouseClicked: boolean = false;
+
+    bbox: any;
+
+    boundaryX1: number = 0;
+    boundaryX2: number = 0;
+    boundaryY1: number = 0;
+    boundaryY2: number = 0;
+
+    minX: number = 0;
+    maxX: number = 0;
+    minY: number = 0;
+    maxY: number = 0;
+
+    ngOnInit(): void {
+        this._sub = this._positionForActivitiesService.boxDimensions$.subscribe(
+            (boxes) => {
+                const relevantBox = boxes.find(
+                    (box) => box.id === this.activity.dfgId,
+                );
+
+                if (relevantBox) {
+                    this.boundaryX1 = relevantBox!.x - relevantBox!.width / 2;
+                    this.boundaryX2 = this.boundaryX1 + relevantBox!.width;
+                    this.boundaryY1 = relevantBox!.y - relevantBox!.height / 2;
+                    this.boundaryY2 = this.boundaryY1 + relevantBox!.height;
+                }
+            },
+        );
+    }
 
     onActivityClick(event: Event, activity: Activity): void {
         const rect = event.target as SVGRectElement;
@@ -77,5 +124,109 @@ export class DrawingActivityComponent {
         this._collectSelectedElementsService.updateSelectedActivity(
             activity.id,
         );
+    }
+
+    startDrag(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        const target = event.target as SVGRectElement;
+        this.mouseClicked = true;
+
+        if (target.classList.contains('draggable')) {
+            this.offset = this.getMousePosition(event);
+            this.elementSelected = target;
+
+            const transforms = this.elementSelected.transform.baseVal;
+
+            if (target.classList.contains('confine')) {
+                this.bbox = target.getBBox();
+                this.minX = this.boundaryX1 - this.bbox.x;
+                this.maxX = this.boundaryX2 - this.bbox.x - this.bbox.width;
+                this.minY = this.boundaryY1 - this.bbox.y;
+                this.maxY = this.boundaryY2 - this.bbox.y - this.bbox.height;
+            }
+
+            if (
+                transforms.length === 0 ||
+                transforms.getItem(0).type !==
+                    SVGTransform.SVG_TRANSFORM_TRANSLATE
+            ) {
+                const translate = svg.createSVGTransform();
+                translate.setTranslate(0, 0);
+
+                this.elementSelected.transform.baseVal.insertItemBefore(
+                    translate,
+                    0,
+                );
+            }
+
+            this.transform = transforms.getItem(0);
+            this.offset.x -= this.transform.matrix.e;
+            this.offset.y -= this.transform.matrix.f;
+        }
+    }
+
+    drag(event: MouseEvent) {
+        const target = event.target as SVGRectElement;
+        if (this.elementSelected !== null) {
+            event.preventDefault();
+            const coord = this.getMousePosition(event);
+
+            if (this.transform !== undefined) {
+                let dx = coord.x - this.offset.x;
+                let dy = coord.y - this.offset.y;
+
+                if (target.classList.contains('confine')) {
+                    if (dx < this.minX) {
+                        dx = this.minX;
+                    } else if (dx > this.maxX) {
+                        dx = this.maxX;
+                    }
+
+                    if (dy < this.minY) {
+                        dy = this.minY;
+                    } else if (dy > this.maxY) {
+                        dy = this.maxY;
+                    }
+                }
+
+                this._positionForActivitiesService.updatePosition(
+                    this.activity.id,
+                    this.activity.dfgId,
+                    dx,
+                    dy,
+                );
+            }
+        }
+    }
+
+    endDrag(event: MouseEvent) {
+        this.elementSelected = null;
+        if (this.mouseClicked) {
+            this._positionForActivitiesService.updateCoordinatesOfArcs(
+                this.activity.id,
+                this.activity.dfgId,
+                this.activity.x,
+                this.activity.y,
+            );
+            this.mouseClicked = false;
+        }
+    }
+
+    private getMousePosition(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        var CTM = svg.getScreenCTM();
+
+        if (!CTM) {
+            throw new Error('CTM is null');
+        }
+
+        return {
+            x: (event.clientX - CTM.e) / CTM.a,
+            y: (event.clientY - CTM.f) / CTM.d,
+        };
     }
 }

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -196,7 +196,6 @@ export class DrawingActivityComponent {
                     this.activity.y,
                 );
                 this.mouseClicked = false;
-                console.log('ResetSelectedArcs');
                 this._collectSelectedElementsService.resetSelectedArcs();
             } else {
                 const rect = event.target as SVGRectElement;

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -5,6 +5,7 @@ import { FallThroughHandlingService } from 'src/app/services/fall-through-handli
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { Subscription } from 'rxjs';
 import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
+import { CollectArcsService } from 'src/app/services/collect-arcs.service';
 
 @Component({
     selector: 'svg:g[app-drawing-activity]',
@@ -54,6 +55,7 @@ export class DrawingActivityComponent {
     constructor(
         private _collectSelectedElementsService: CollectSelectedElementsService,
         private _positionForActivitiesService: PositionForActivitiesService,
+        private _collectArcsService: CollectArcsService,
     ) {}
 
     readonly width: number = environment.drawingElements.activities.height;
@@ -211,6 +213,7 @@ export class DrawingActivityComponent {
                 this.activity.y,
             );
             this.mouseClicked = false;
+            this._collectArcsService.resetCollectedArcs();
         }
     }
 

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -4,6 +4,8 @@ import { environment } from 'src/environments/environment';
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
 import { PetriNetManagementService } from 'src/app/services/petri-net-management.service';
+import { Subscription } from 'rxjs';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
 
 @Component({
     selector: 'svg:g[app-drawing-arc]',
@@ -44,18 +46,18 @@ import { PetriNetManagementService } from 'src/app/services/petri-net-management
         </svg:defs>
 
         <svg:path
-            [attr.d]="pathForLine(arc)"
+            [attr.d]="setPath(arc)"
             [attr.stroke-width]="10"
             [attr.fill]="'none'"
             fill="transparent"
-            pointer-events="all"
+            pointer-events="stroke"
             (pointerenter)="changeLineColorOver($event, arc)"
             (pointerleave)="changeLineColorOut($event)"
             (click)="onLineClick($event, arc)"
         ></svg:path>
         <svg:path
             [attr.class]="'visiblePath'"
-            [attr.d]="pathForLine(arc)"
+            [attr.d]="setPath(arc)"
             [attr.stroke]="'black'"
             [attr.stroke-width]="width"
             [attr.fill]="'none'"
@@ -83,12 +85,40 @@ export class DrawingArcComponent {
         private collectSelectedElementsService: CollectSelectedElementsService,
         private feedbackService: ShowFeedbackService,
         private petriNetManagementService: PetriNetManagementService,
+        private positionForActivitiesService: PositionForActivitiesService,
     ) {}
 
     readonly width: number = environment.drawingElements.arcs.width;
     readonly color: string = environment.drawingElements.arcs.color;
     rectheight = 10;
     private timeoutId: any;
+    private _sub: Subscription | undefined;
+    private _sub2: Subscription | undefined;
+
+    private movingActivityID: string = '';
+    private xTranslate = 0;
+    private yTranslate = 0;
+    private movedActivityIdToSetNewCoordinates: string = '';
+    private updateCoordinates = false;
+
+    ngOnInit(): void {
+        this._sub =
+            this.positionForActivitiesService.movingActivityInGraph$.subscribe(
+                (position) => {
+                    this.movingActivityID = position[0];
+                    this.xTranslate = position[2];
+                    this.yTranslate = position[3];
+                },
+            );
+
+        this._sub2 =
+            this.positionForActivitiesService.updateArcCoordinates$.subscribe(
+                (coordinate) => {
+                    this.movedActivityIdToSetNewCoordinates = coordinate[0];
+                    this.updateCoordinates = true;
+                },
+            );
+    }
 
     changeLineColorOver(event: Event, arc: Arc): void {
         const pathDummy = event.target as SVGPathElement;
@@ -200,7 +230,7 @@ export class DrawingArcComponent {
         );
     }
 
-    pathForLine(arc: Arc): string {
+    setPath(arc: Arc): string {
         if (!this.pathNecessary(arc)) {
             return `M ${arc.x1} ${arc.y1} L ${arc.x2} ${arc.y2}`;
         }

--- a/src/app/components/drawing-area/drawing-area.component.ts
+++ b/src/app/components/drawing-area/drawing-area.component.ts
@@ -27,6 +27,8 @@ import {
     Transition,
     TransitionToPlaceArc,
 } from './models';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
+import _ from 'lodash';
 
 @Component({
     selector: 'app-drawing-area',
@@ -38,6 +40,10 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
 
     private _sub: Subscription | undefined;
     private observer!: MutationObserver;
+    private _sub2: Subscription | undefined;
+    private _sub3: Subscription | undefined;
+
+    private _graph: Graph | undefined;
 
     private _activities: Array<Activity> = new Array<Activity>();
     private _boxes: Array<Box> = new Array<Box>();
@@ -46,9 +52,17 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
     private _arcs: Array<Arc> = new Array<Arc>();
     private _boxArcs: Array<Arc> = new Array<Arc>();
 
+    private _originalPositionOfActivities: Array<Activity> =
+        new Array<Activity>();
+    private _lastPositionOfActivities: Array<Activity> = new Array<Activity>();
+    private _activityMoved = new Array<[activityId: string, dfgId: string]>();
+
     public showEventLogs: boolean = false;
 
-    constructor(private calculatePetriNetService: CalculatePetriNetService) {}
+    constructor(
+        private calculatePetriNetService: CalculatePetriNetService,
+        private positionForActivitiesService: PositionForActivitiesService,
+    ) {}
 
     get activities(): Array<Activity> {
         return this._activities;
@@ -77,12 +91,13 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         this._sub = this.calculatePetriNetService.graph$.subscribe(
             (graph: Graph) => {
+                this._graph = graph;
                 const places: Array<Place> = new Array<Place>();
                 const activities: Array<Activity> = new Array<Activity>();
                 const transitions: Array<Transition> = new Array<Transition>();
                 const boxes: Array<Box> = new Array<Box>();
 
-                graph.nodes.forEach((node) => {
+                this._graph.nodes.forEach((node) => {
                     if (node instanceof ActivityNode) {
                         activities.push(new Activity(node as ActivityNode));
                     }
@@ -105,7 +120,7 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
                 const arcs: Array<Arc> = new Array<Arc>();
                 const boxArcs: Array<Arc> = new Array<Arc>();
 
-                graph.edges.forEach((edge) => {
+                this._graph.edges.forEach((edge) => {
                     if (edge.source instanceof ActivityNode) {
                         const startActivity = activities.find(
                             (activity) =>
@@ -185,6 +200,11 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
                 this._places = places;
                 this._arcs = arcs;
                 this._boxArcs = boxArcs;
+
+                this._originalPositionOfActivities = _.cloneDeep(activities);
+                this._lastPositionOfActivities = _.cloneDeep(activities);
+
+                this.positionForActivitiesService.passBoxObjects(boxes);
             },
         );
 
@@ -199,6 +219,93 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
                 subtree: false,
                 attributes: false,
             });
+        }
+
+        this._sub2 =
+            this.positionForActivitiesService.movingActivityInGraph$.subscribe(
+                (activity) => {
+                    const activityId = activity[0];
+                    const dfgId = activity[1];
+                    const xTranslate = activity[2];
+                    const yTranslate = activity[3];
+
+                    const movedActivity = this._activities.find(
+                        (activity) =>
+                            activity.id === activityId &&
+                            activity.dfgId === dfgId,
+                    );
+
+                    if (movedActivity) {
+                        if (
+                            this._activityMoved.filter(
+                                (activity) =>
+                                    activity[0] === movedActivity.id &&
+                                    activity[1] === movedActivity.dfgId,
+                            ).length === 0
+                        ) {
+                            const originalX =
+                                this._originalPositionOfActivities.find(
+                                    (activity) =>
+                                        activity.id === activityId &&
+                                        activity.dfgId === dfgId,
+                                )!.x;
+
+                            const originalY =
+                                this._originalPositionOfActivities.find(
+                                    (activity) =>
+                                        activity.id === activityId &&
+                                        activity.dfgId === dfgId,
+                                )!.y;
+
+                            movedActivity.x = originalX + xTranslate;
+                            movedActivity.y = originalY + yTranslate;
+                            this.updateDfgArcs();
+                        } else {
+                            const lastX = this._lastPositionOfActivities.find(
+                                (activity) =>
+                                    activity.id === activityId &&
+                                    activity.dfgId === dfgId,
+                            )!.x;
+
+                            const lastY = this._lastPositionOfActivities.find(
+                                (activity) =>
+                                    activity.id === activityId &&
+                                    activity.dfgId === dfgId,
+                            )!.y;
+
+                            movedActivity.x = lastX + xTranslate;
+                            movedActivity.y = lastY + yTranslate;
+                            this.updateDfgArcs();
+                        }
+                    }
+                },
+            );
+
+        this._sub3 =
+            this.positionForActivitiesService.updateArcCoordinates$.subscribe(
+                (activity) => {
+                    this.updateActivtyMoved(activity[0], activity[1]);
+                    const entryCurrentActivity =
+                        this._lastPositionOfActivities.find(
+                            (activity2) =>
+                                activity2.id === activity[0] &&
+                                activity2.dfgId === activity[1],
+                        );
+                    if (entryCurrentActivity) {
+                        entryCurrentActivity.x = activity[2];
+                        entryCurrentActivity.y = activity[3];
+                    }
+                },
+            );
+    }
+
+    updateActivtyMoved(activityID: string, dfgId: string) {
+        const activityEntry = this._activityMoved.filter(
+            (activity) => activity[0] === activityID && activity[1] === dfgId,
+        );
+
+        if (activityEntry.length === 0) {
+            this._activityMoved.push([activityID, dfgId]);
         }
     }
 
@@ -224,6 +331,32 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
         }
     }
 
+    updateDfgArcs(): void {
+        const boxArcs: Array<Arc> = new Array<Arc>();
+
+        this._graph?.edges.forEach((edge) => {
+            if (edge.source instanceof ActivityNode) {
+                const startActivity = this._activities.find(
+                    (activity) =>
+                        activity.id === edge.source.id &&
+                        activity.x === edge.source.x &&
+                        activity.y === edge.source.y,
+                )!;
+
+                const endActivity = this._activities.find(
+                    (activity) =>
+                        activity.id === edge.target.id &&
+                        activity.x === edge.target.x &&
+                        activity.y === edge.target.y,
+                )!;
+
+                boxArcs.push(new DfgArc(startActivity, endActivity));
+            }
+        });
+
+        this._boxArcs = boxArcs;
+    }
+
     mouseDown(): void {
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
@@ -231,7 +364,6 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
 
         if (svg) {
             svg.classList.add('mouseDown');
-            console.log('Mouse Down');
         }
     }
 
@@ -242,7 +374,6 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
 
         if (svg) {
             svg.classList.remove('mouseDown');
-            console.log('Mouse Up');
         }
     }
 }

--- a/src/app/components/drawing-area/models/nodes.ts
+++ b/src/app/components/drawing-area/models/nodes.ts
@@ -20,6 +20,14 @@ export abstract class Node {
     get y(): number {
         return this._node.y;
     }
+
+    set x(x: number) {
+        this._node.x = x;
+    }
+
+    set y(y: number) {
+        this._node.y = y;
+    }
 }
 
 export class Place extends Node {
@@ -29,8 +37,16 @@ export class Place extends Node {
 }
 
 export class Activity extends Node {
+    private readonly _dfgId: string;
+
     constructor(node: ActivityNode) {
         super(node);
+
+        this._dfgId = node.dfg;
+    }
+
+    get dfgId(): string {
+        return this._dfgId;
     }
 }
 
@@ -58,7 +74,7 @@ export class Box extends Node {
 
         this._width = node.width;
         this._height = node.height;
-        this._eventLog = node.eventLog
+        this._eventLog = node.eventLog;
     }
 
     get width(): number {

--- a/src/app/services/calculate-coordinates.service.ts
+++ b/src/app/services/calculate-coordinates.service.ts
@@ -72,6 +72,7 @@ export class CalculateCoordinatesService {
                 playActivity.name,
                 initialXCoordinate,
                 initialYCoordinate,
+                dfg.id,
             ),
         );
         const neighbours: Activities =
@@ -103,6 +104,7 @@ export class CalculateCoordinatesService {
                 stackElement.activity.name,
                 stackElement.source_x + gapX,
                 yCoordinate,
+                dfg.id,
             );
             nodes.push(activityAsNode);
 

--- a/src/app/services/calculate-coordinates.service.ts
+++ b/src/app/services/calculate-coordinates.service.ts
@@ -320,8 +320,6 @@ export class CalculateCoordinatesService {
             p.shift();
         });
 
-        console.log(allPaths);
-
         return allPaths;
     }
 }

--- a/src/app/services/collect-selected-elements.service.ts
+++ b/src/app/services/collect-selected-elements.service.ts
@@ -75,17 +75,14 @@ export class CollectSelectedElementsService {
     }
 
     public resetSelectedElements(): void {
-        this._collectedArcs = new Arcs();
-        this._currentCollectedArcsDFG = undefined;
-        this._selectedActivity = undefined;
-        this._selectedDFGBox = undefined;
-
-        this.resetClickedArcs();
+        this.resetSelectedArcs();
         this.resetSelectedActivity();
         this.resetSelectedDFGBox();
     }
 
-    private resetClickedArcs(): void {
+    resetSelectedArcs(): void {
+        this._collectedArcs = new Arcs();
+        this._currentCollectedArcsDFG = undefined;
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
         )[0] as SVGSVGElement;
@@ -102,7 +99,9 @@ export class CollectSelectedElementsService {
         }
     }
 
-    private resetSelectedActivity(): void {
+    resetSelectedActivity(): void {
+        this.resetSelectedActivity();
+        this._selectedActivity = undefined;
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
         )[0] as SVGSVGElement;
@@ -115,7 +114,9 @@ export class CollectSelectedElementsService {
         }
     }
 
-    private resetSelectedDFGBox(): void {
+    resetSelectedDFGBox(): void {
+        this.resetSelectedDFGBox();
+        this._selectedDFGBox = undefined;
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
         )[0] as SVGSVGElement;

--- a/src/app/services/collect-selected-elements.service.ts
+++ b/src/app/services/collect-selected-elements.service.ts
@@ -100,7 +100,6 @@ export class CollectSelectedElementsService {
     }
 
     resetSelectedActivity(): void {
-        this.resetSelectedActivity();
         this._selectedActivity = undefined;
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
@@ -115,7 +114,6 @@ export class CollectSelectedElementsService {
     }
 
     resetSelectedDFGBox(): void {
-        this.resetSelectedDFGBox();
         this._selectedDFGBox = undefined;
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',

--- a/src/app/services/position-for-activities.service.ts
+++ b/src/app/services/position-for-activities.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Activity, Arc, Box } from '../components/drawing-area';
+import { BoxNode } from '../classes/graph';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class PositionForActivitiesService {
+    constructor() {}
+
+    //--------- Subscription 1 ---------
+    private readonly _movingActivityInGraph$: BehaviorSubject<
+        [activityId: string, dfgId: string, x: number, y: number]
+    > = new BehaviorSubject<
+        [activityId: string, dfgId: string, x: number, y: number]
+    >(['', '', 0, 0]);
+
+    get movingActivityInGraph$(): Observable<
+        [activityId: string, dfgId: string, x: number, y: number]
+    > {
+        return this._movingActivityInGraph$.asObservable();
+    }
+
+    //--------- Subscription 2 ---------
+    private readonly _updateArcCoordinates$: BehaviorSubject<
+        [activityId: string, dfgId: string, x: number, y: number]
+    > = new BehaviorSubject<
+        [activityId: string, dfgId: string, x: number, y: number]
+    >(['', '', 0, 0]);
+
+    get updateArcCoordinates$(): Observable<
+        [activityId: string, dfgId: string, x: number, y: number]
+    > {
+        return this._updateArcCoordinates$.asObservable();
+    }
+
+    //--------- Subscription 3 ---------
+    private readonly _boxDimensions$: BehaviorSubject<Box[]> =
+        new BehaviorSubject<Box[]>([]);
+
+    get boxDimensions$(): Observable<Box[]> {
+        return this._boxDimensions$.asObservable();
+    }
+
+    updatePosition(
+        activityId: string,
+        dfgId: string,
+        xTranslate: number,
+        yTranslate: number,
+    ) {
+        this._movingActivityInGraph$.next([
+            activityId,
+            dfgId,
+            xTranslate,
+            yTranslate,
+        ]);
+    }
+
+    updateCoordinatesOfArcs(
+        activityId: string,
+        dfgId: string,
+        newX: number,
+        newY: number,
+    ): void {
+        this._updateArcCoordinates$.next([activityId, dfgId, newX, newY]);
+    }
+
+    passBoxObjects(box: Box[]): void {
+        this._boxDimensions$.next(box);
+    }
+}


### PR DESCRIPTION
- Activities sind nun ziehbar
- Arcs werden neu berechnet und Pfeilspitze wandert entsprechend mit
- Da Kanten nun neu geladen werden und dadurch die Standardfarbe, also aktuell Schwarz, wieder gesetzt wird, werden vorher selektierte Kanten wieder zurückgesetzt. Für das speichern der selektierten Kanten wurde SCRUM-95 angelegt
- Klickbarer Bereich der Kante noch angepasst. Nun ist bei gebogenen Arcs nur die Linie anklickbar und nicht mehr auch der "Zwischenraum", der ensteht, wenn man von Start zu Ziel noch eine Gerade ziehen würde

Zu klären ist noch:
- Pfeilrichtung bei gebogenen, doppelten Kanten werden vertauscht, wenn sie die Waagerechte überschreibten. Ist das störend?
- Die Zieh-Beschränkung der Activities, damit sie nur innerhalb der DFG-Box verschoben werden können, basiert derzeit auf Activity selbst. D.h. der Name der Activity wird ggf. außerhalb der Box angezeigt, sollte er länger als die Activity selbst. Soll das anhand des Namens der Activity begrenzt werden? Bei langen Namen könnte das dann dazu führen, dass sich die Activity nicht wirklich weit verschieben lässt.
- Soll es eine Funktionalität geben, die die Positionen aller Activities wieder auf den originalen Zustand zurücksetzt?