### PR TITLE
SCRUM-69-Anpassung-der-Beispiel-Eventlogs

### DIFF
--- a/src/app/components/example-event-logs/example-event-logs.component.html
+++ b/src/app/components/example-event-logs/example-event-logs.component.html
@@ -19,5 +19,8 @@
         <button mat-mini-fab (click)="generateFlowerExample()">
             <mat-icon>filter_vintage</mat-icon>
         </button>
+        <button mat-mini-fab (click)="generateFUHProcessMiningExample()">
+            <mat-icon>school</mat-icon>
+        </button>
     </div>
 </div>

--- a/src/app/components/example-event-logs/example-event-logs.component.html
+++ b/src/app/components/example-event-logs/example-event-logs.component.html
@@ -1,14 +1,23 @@
 <div>
-    <h3>Example Generator</h3>
+    <h3>Event Log Examples</h3>
     <div class="example-generator-flex-container">
-        <button mat-mini-fab (click)="generateEasyExample()">
-            <mat-icon>signal_cellular_alt_1_bar</mat-icon>
+        <button mat-mini-fab (click)="generateExclusiveExample()">
+            <mat-icon>call_split</mat-icon>
         </button>
-        <button mat-mini-fab (click)="generateMediumExample()">
-            <mat-icon>signal_cellular_alt_2_bar</mat-icon>
+        <button mat-mini-fab (click)="generateSequenceExample()">
+            <mat-icon>straight</mat-icon>
         </button>
-        <button mat-mini-fab (click)="generateComplexExample()">
-            <mat-icon>signal_cellular_alt_3_bar</mat-icon>
+        <button mat-mini-fab (click)="generateParallelExample()">
+            <mat-icon>alt_route</mat-icon>
+        </button>
+        <button mat-mini-fab (click)="generateLoopExample()">
+            <mat-icon>repeat</mat-icon>
+        </button>
+        <button mat-mini-fab (click)="generateAOPTExample()">
+            <mat-icon>looks_one</mat-icon>
+        </button>
+        <button mat-mini-fab (click)="generateFlowerExample()">
+            <mat-icon>filter_vintage</mat-icon>
         </button>
     </div>
 </div>

--- a/src/app/components/example-event-logs/example-event-logs.component.ts
+++ b/src/app/components/example-event-logs/example-event-logs.component.ts
@@ -20,56 +20,77 @@ export class ExampleEventLogsComponent {
         private _calculateDfgService: CalculateDfgService,
     ) {}
 
-    public generateEasyExample(): void {
+    public generateExclusiveExample(): void {
+        const traces: Trace[] = [
+            new Trace([new Activity('Order')]),
+            new Trace([new Activity('Request')]),
+        ];
+        const eventLog: EventLog = new EventLog(traces);
+        this.initializePetriNet(eventLog);
+    }
+
+    generateSequenceExample(): void {
+        const traces: Trace[] = [
+            new Trace([new Activity('Order'), new Activity('Confirm')]),
+        ];
+        const eventLog: EventLog = new EventLog(traces);
+        this.initializePetriNet(eventLog);
+    }
+
+    public generateParallelExample(): void {
+        const traces: Trace[] = [
+            new Trace([new Activity('Request'), new Activity('Order')]),
+            new Trace([new Activity('Order'), new Activity('Request')]),
+        ];
+        const eventLog: EventLog = new EventLog(traces);
+        this.initializePetriNet(eventLog);
+    }
+
+    generateLoopExample(): void {
         const traces: Trace[] = [
             new Trace([
-                new Activity('A'),
-                new Activity('B'),
-                new Activity('C'),
+                new Activity('Request'),
+                new Activity('Process'),
+                new Activity('Reject'),
+                new Activity('Request'),
+                new Activity('Process'),
             ]),
         ];
         const eventLog: EventLog = new EventLog(traces);
         this.initializePetriNet(eventLog);
     }
 
-    public generateMediumExample(): void {
+    public generateAOPTExample(): void {
         const traces: Trace[] = [
+            new Trace([new Activity('Request'), new Activity('Order')]),
+            new Trace([new Activity('Order'), new Activity('Request')]),
             new Trace([
-                new Activity('A'),
-                new Activity('B'),
-                new Activity('C'),
+                new Activity('Order'),
+                new Activity('Request'),
+                new Activity('Confirm'),
             ]),
             new Trace([
-                new Activity('A'),
-                new Activity('Y'),
-                new Activity('Z'),
+                new Activity('Request'),
+                new Activity('Confirm'),
+                new Activity('Order'),
             ]),
         ];
         const eventLog: EventLog = new EventLog(traces);
         this.initializePetriNet(eventLog);
     }
 
-    public generateComplexExample(): void {
+    public generateFlowerExample(): void {
         const traces: Trace[] = [
             new Trace([
-                new Activity('A'),
-                new Activity('B'),
-                new Activity('C'),
+                new Activity('Request'),
+                new Activity('Confirm'),
+                new Activity('Request'),
+                new Activity('Confirm'),
             ]),
             new Trace([
-                new Activity('U'),
-                new Activity('V'),
-                new Activity('W'),
-                new Activity('X'),
-                new Activity('Y'),
-                new Activity('Z'),
-            ]),
-            new Trace([
-                new Activity('U'),
-                new Activity('X'),
-                new Activity('Z'),
-                new Activity('A'),
-                new Activity('C'),
+                new Activity('Request'),
+                new Activity('Order'),
+                new Activity('Confirm'),
             ]),
         ];
         const eventLog: EventLog = new EventLog(traces);

--- a/src/app/components/example-event-logs/example-event-logs.component.ts
+++ b/src/app/components/example-event-logs/example-event-logs.component.ts
@@ -97,6 +97,49 @@ export class ExampleEventLogsComponent {
         this.initializePetriNet(eventLog);
     }
 
+    public generateFUHProcessMiningExample(): void {
+        const traces: Trace[] = [
+            new Trace([new Activity('SetPc'), new Activity('SetCfp')]),
+            new Trace([
+                new Activity('SuggestPc'),
+                new Activity('SetUpCfp'),
+                new Activity('SendInvites'),
+                new Activity('ReceiveAnswers'),
+                new Activity('FinalizePc'),
+                new Activity('FinalizeCfp'),
+            ]),
+            new Trace([
+                new Activity('SuggestPc'),
+                new Activity('SendInvites'),
+                new Activity('SetUpCfp'),
+                new Activity('ReceiveAnswers'),
+                new Activity('FinalizePc'),
+                new Activity('FinalizeCfp'),
+            ]),
+            new Trace([
+                new Activity('SuggestPc'),
+                new Activity('SendInvites'),
+                new Activity('ReceiveAnswers'),
+                new Activity('SetUpCfp'),
+                new Activity('FinalizePc'),
+                new Activity('FinalizeCfp'),
+            ]),
+            new Trace([
+                new Activity('SuggestPc'),
+                new Activity('SendInvites'),
+                new Activity('ReceiveAnswers'),
+                new Activity('UpdateInvitees'),
+                new Activity('SendInvites'),
+                new Activity('ReceiveAnswers'),
+                new Activity('FinalizePc'),
+                new Activity('SetUpCfp'),
+                new Activity('FinalizeCfp'),
+            ]),
+        ];
+        const eventLog: EventLog = new EventLog(traces);
+        this.initializePetriNet(eventLog);
+    }
+
     private initializePetriNet(eventLog: EventLog): void {
         Dfg.resetIdCount();
         const dfg: Dfg = this._calculateDfgService.calculate(eventLog);


### PR DESCRIPTION
Beispiele sind hoffentlich etwas sprechender. Allerdings haben diese keinen Bezug zum Kurstext, da ich nicht finde, dass das Beispiel im Kurstext sehr eindrücklich ist. Weiter sind in diesem auch nicht alle Cut-Arten vertreten. Aktuell ein Beispiel pro Cut-Art und bei manchen notgedrungen noch weitere anschließende Cuts möglich. Aber bei Aufruf ist der jeweilige Cut bzw. Fall-Through durchzuführen.