### PR TITLE
SCRUM-74-Cuts-sichtbarer-machen

### DIFF
--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -36,12 +36,12 @@ import { Activity } from '../models';
     styles: `
         rect:hover {
             cursor: pointer;
-            stroke-width: 3;
+            stroke-width: 4;
             stroke-opacity: 0.5;
         }
         rect.activity-marked {
-            stroke-width: 3;
-            stroke: #ebce97;
+            stroke-width: 4;
+            stroke: #b8860b;
         }
         .draggable {
             cursor: move;

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -40,8 +40,10 @@ import { Activity } from '../models';
             stroke-opacity: 0.5;
         }
         rect.activity-marked {
-            stroke-width: 4;
+            stroke-width: 3;
             stroke: #b8860b;
+            // stroke: #146869;
+            // stroke: #d42f7c;
         }
         .draggable {
             cursor: move;

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -41,7 +41,7 @@ import { Activity } from '../models';
         }
         rect.activity-marked {
             stroke-width: 3;
-            stroke: rgb(228, 54, 115);
+            stroke: #ebce97;
         }
         .draggable {
             cursor: move;

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -36,12 +36,12 @@ import { Activity } from '../models';
     styles: `
         rect:hover {
             cursor: pointer;
-            stroke-width: 5;
-            stroke: #085c5c;
+            stroke-width: 3;
+            stroke-opacity: 0.5;
         }
         rect.activity-marked {
-            stroke-width: 5;
-            stroke: #085c5c;
+            stroke-width: 3;
+            stroke: rgb(228, 54, 115);
         }
         .draggable {
             cursor: move;

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -27,8 +27,9 @@ import { Activity } from '../models';
             (mouseleave)="endDrag($event, activity)"
         />
         <svg:text
-            [attr.x]="activity.x - activity.id.length * 4.8"
+            [attr.x]="activity.x - activity.id.length * 3.8"
             [attr.y]="activity.y + (height + strokeWidth) / 2 + 20"
+            [attr.font-size]="13"
         >
             {{ activity.id }}
         </svg:text>

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -42,9 +42,7 @@ import { Activity } from '../models';
         }
         rect.activity-marked {
             stroke-width: 3;
-            stroke: #b8860b;
-            // stroke: #146869;
-            // stroke: #d42f7c;
+            stroke: #d42f7c;
         }
         .draggable {
             cursor: move;

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -28,7 +28,7 @@ import { Arc } from '../models';
                 ></svg:path>
             </svg:marker>
             <svg:marker
-                id="arrowhead-white"
+                id="arrowhead-bright"
                 viewBox="0 0 10 10"
                 markerWidth="10"
                 markerHeight="10"
@@ -38,8 +38,8 @@ import { Arc } from '../models';
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="'#afafaf'"
-                    [attr.stroke]="'#afafaf'"
+                    [attr.fill]="'#e6cd1c'"
+                    [attr.stroke]="'#e6cd1c'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -38,8 +38,8 @@ import { Arc } from '../models';
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="'white'"
-                    [attr.stroke]="'white'"
+                    [attr.fill]="'#afafaf'"
+                    [attr.stroke]="'#afafaf'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>

--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -28,7 +28,7 @@ import { Arc } from '../models';
                 ></svg:path>
             </svg:marker>
             <svg:marker
-                id="arrowhead-red"
+                id="arrowhead-white"
                 viewBox="0 0 10 10"
                 markerWidth="10"
                 markerHeight="10"
@@ -38,8 +38,8 @@ import { Arc } from '../models';
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="'red'"
-                    [attr.stroke]="'red'"
+                    [attr.fill]="'white'"
+                    [attr.stroke]="'white'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -20,8 +20,9 @@ import { Box } from '../models';
             (click)="onBoxClick($event, box)"
         />
         <svg:text
-            [attr.x]="box.x - box.id.length * 4.8"
+            [attr.x]="box.x - box.id.length * 3.8"
             [attr.y]="box.y + (box.height + strokeWidth) / 2 + 20"
+            [attr.font-size]="13"
         >
             {{ box.id }}
         </svg:text>

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -46,7 +46,7 @@ import { Box } from '../models';
             stroke-opacity: 0.5;
         }
         rect.box-marked {
-            stroke:rgb(228, 54, 115);
+            stroke: #ebce97;
             stroke-width: 5;
         }
         .event-log {

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -47,6 +47,8 @@ import { Box } from '../models';
         }
         rect.box-marked {
             stroke: #b8860b;
+            // stroke: #146869;
+            // stroke: #d42f7c;
             stroke-width: 5;
         }
         .event-log {

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -42,12 +42,12 @@ import { Box } from '../models';
     styles: `
         rect:hover {
             cursor: pointer;
-            stroke-width: 4;
+            stroke-width: 5;
             stroke-opacity: 0.5;
         }
         rect.box-marked {
             stroke:rgb(228, 54, 115);
-            stroke-width: 4;
+            stroke-width: 5;
         }
         .event-log {
             height: 100%;

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -47,9 +47,7 @@ import { Box } from '../models';
             stroke-opacity: 0.5;
         }
         rect.box-marked {
-            stroke: #b8860b;
-            // stroke: #146869;
-            // stroke: #d42f7c;
+            stroke: #d42f7c;
             stroke-width: 5;
         }
         .event-log {

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -46,7 +46,7 @@ import { Box } from '../models';
             stroke-opacity: 0.5;
         }
         rect.box-marked {
-            stroke: #ebce97;
+            stroke: #b8860b;
             stroke-width: 5;
         }
         .event-log {

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -42,12 +42,12 @@ import { Box } from '../models';
     styles: `
         rect:hover {
             cursor: pointer;
-            stroke-width: 7;
-            stroke: #085c5c;
+            stroke-width: 4;
+            stroke-opacity: 0.5;
         }
         rect.box-marked {
-            stroke: #085c5c;
-            stroke-width: 7;
+            stroke:rgb(228, 54, 115);
+            stroke-width: 4;
         }
         .event-log {
             height: 100%;

--- a/src/app/components/drawing-area/components/drawing-boxArc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-boxArc.component.ts
@@ -38,8 +38,8 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="'#ebce97'"
-                    [attr.stroke]="'#ebce97'"
+                    [attr.fill]="'#bebebe'"
+                    [attr.stroke]="'#bebebe'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>
@@ -70,13 +70,11 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
         }
 
         path.active {
-            stroke: #ebce97 !important;
-            // stroke: #bebebe !important;
+            stroke: #bebebe !important;
         }
 
         path.hovered {
-            stroke: #ebce97 !important;
-            // stroke: #bebebe !important;
+            stroke: #bebebe !important;
         }
     `,
 })

--- a/src/app/components/drawing-area/components/drawing-boxArc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-boxArc.component.ts
@@ -71,10 +71,12 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
 
         path.active {
             stroke: #ebce97 !important;
+            // stroke: #bebebe !important;
         }
 
         path.hovered {
             stroke: #ebce97 !important;
+            // stroke: #bebebe !important;
         }
     `,
 })

--- a/src/app/components/drawing-area/components/drawing-boxArc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-boxArc.component.ts
@@ -28,7 +28,7 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
                 ></svg:path>
             </svg:marker>
             <svg:marker
-                id="arrowhead-red"
+                id="arrowhead-pale"
                 viewBox="0 0 10 10"
                 markerWidth="10"
                 markerHeight="10"
@@ -38,8 +38,8 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
             >
                 <svg:path
                     d="M 1,1 L 9,5 L 1,9 Z"
-                    [attr.fill]="'red'"
-                    [attr.stroke]="'red'"
+                    [attr.fill]="'#ebce97'"
+                    [attr.stroke]="'#ebce97'"
                     [attr.stroke-width]="width"
                 ></svg:path>
             </svg:marker>
@@ -70,11 +70,11 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
         }
 
         path.active {
-            stroke: red !important;
+            stroke: #ebce97 !important;
         }
 
         path.hovered {
-            stroke: red !important;
+            stroke: #ebce97 !important;
         }
     `,
 })
@@ -137,7 +137,7 @@ export class DrawingBoxArcComponent {
                 !path.classList.contains('active')
             ) {
                 path.classList.add('hovered');
-                path.setAttribute('marker-end', 'url(#arrowhead-red)');
+                path.setAttribute('marker-end', 'url(#arrowhead-pale)');
             } else if (svg.classList.contains('mouseDown')) {
                 this.timeoutId = setTimeout(() => {
                     if (
@@ -147,7 +147,7 @@ export class DrawingBoxArcComponent {
                             path.classList.toggle('active');
                             path.setAttribute(
                                 'marker-end',
-                                'url(#arrowhead-red)',
+                                'url(#arrowhead-pale)',
                             );
                         } else {
                             path.classList.toggle('active');

--- a/src/app/components/drawing-area/components/drawing-place.component.ts
+++ b/src/app/components/drawing-area/components/drawing-place.component.ts
@@ -21,8 +21,9 @@ import { Place } from '../models';
             [attr.stroke-width]="strokeWidth"
         />
         <svg:text
-            [attr.x]="place.x - place.id.length * 4.8"
+            [attr.x]="place.x - place.id.length * 3.8"
             [attr.y]="place.y + radius + strokeWidth / 2 + 20"
+            [attr.font-size]="13"
         >
             {{ place.id }}
         </svg:text>

--- a/src/app/components/drawing-area/components/drawing-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-transition.component.ts
@@ -17,8 +17,9 @@ import { Transition } from '../models';
             [attr.stroke-width]="strokeWidth"
         />
         <svg:text
-            [attr.x]="transition.x - transition.name.length * 4.8"
+            [attr.x]="transition.x - transition.name.length * 3.8"
             [attr.y]="transition.y + (height + strokeWidth) / 2 + 20"
+            [attr.font-size]="13"
         >
             {{ transition.name }}
         </svg:text>

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,7 +16,8 @@ export const environment = {
             strokeWidth: 2,
         },
         boxes: {
-            bgColor:'#fdf5e6',
+            bgColor: '#fdf5e6',
+            // bgColor: '#eeeeee',
             bgOpacity: '1',
             strokeColor: 'black',
             strokeOpacity: '1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,7 +16,7 @@ export const environment = {
             strokeWidth: 2,
         },
         boxes: {
-            bgColor: ' #ffe843',
+            bgColor: ' #fdf5e6',
             bgOpacity: '1',
             strokeColor: 'black',
             strokeOpacity: '1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -32,8 +32,8 @@ export const environment = {
             strokeWidth: 2,
         },
         invisibleTransitions: {
-            width: 20,
-            height: 40,
+            width: 15,
+            height: 30,
             bgColor: 'black',
             bgOpacity: '1',
             strokeColor: 'black',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,8 +1,8 @@
 export const environment = {
     production: false,
     drawingGrid: {
-        gapX: 150,
-        gapY: 150,
+        gapX: 120,
+        gapY: 120,
     },
     drawingElements: {
         activities: {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,7 +16,7 @@ export const environment = {
             strokeWidth: 2,
         },
         boxes: {
-            bgColor: ' #fdf5e6',
+            bgColor:'#fdf5e6',
             bgOpacity: '1',
             strokeColor: 'black',
             strokeOpacity: '1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,8 +16,7 @@ export const environment = {
             strokeWidth: 2,
         },
         boxes: {
-            bgColor: '#fdf5e6',
-            // bgColor: '#eeeeee',
+            bgColor: '#eeeeee',
             bgOpacity: '1',
             strokeColor: 'black',
             strokeOpacity: '1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,7 +16,7 @@ export const environment = {
             strokeWidth: 2,
         },
         boxes: {
-            bgColor: 'lightgrey',
+            bgColor: ' #ffe843',
             bgOpacity: '1',
             strokeColor: 'black',
             strokeOpacity: '1',


### PR DESCRIPTION
Die Kanten werden jetzt einfach hell und nicht merh rot. Ich denke es macht die Unterscheidung auf dem grauen Hintergrund etwas einfacher. Ich sicher nicht high-end, aber ich finde der Kontrast ist noch ausreichend und die Trennung etwas besser. Somit wird es auch nicht immer noch bunter in unserer Anwendung, wenn dann noch die gefärbten Kanten aus SCRUM-26 dazu kommen.

Bitte testen und Feedback was ihr meint.