### PR TITLE
Scrum 70 optische anpassung graph elemente

### DIFF
--- a/src/app/classes/graph.ts
+++ b/src/app/classes/graph.ts
@@ -125,6 +125,8 @@ export class TransitionNode extends Node {
     }
 }
 
+export class InvisibleTransitionNode extends TransitionNode {}
+
 export class BoxNode extends Node {
     constructor(
         _id: string,

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Activity, Box } from '../models';
 import { environment } from 'src/environments/environment';
-import { FallThroughHandlingService } from 'src/app/services/fall-through-handling.service';
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { Subscription } from 'rxjs';
 import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
@@ -14,8 +13,8 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
             [attr.y]="activity.y - height / 2"
             [attr.height]="height"
             [attr.width]="width"
-            [attr.rx]="10"
-            [attr.ry]="10"
+            [attr.rx]="radius"
+            [attr.ry]="radius"
             [attr.fill]="bgColor"
             [attr.fill-opacity]="bgOpacity"
             [attr.stroke]="strokeColor"
@@ -59,6 +58,7 @@ export class DrawingActivityComponent {
 
     readonly width: number = environment.drawingElements.activities.height;
     readonly height: number = environment.drawingElements.activities.height;
+    readonly radius: number = environment.drawingElements.activities.radius;
 
     readonly bgColor: string = environment.drawingElements.activities.bgColor;
     readonly bgOpacity: string =

--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -14,6 +14,8 @@ import { PositionForActivitiesService } from 'src/app/services/position-for-acti
             [attr.y]="activity.y - height / 2"
             [attr.height]="height"
             [attr.width]="width"
+            [attr.rx]="10"
+            [attr.ry]="10"
             [attr.fill]="bgColor"
             [attr.fill-opacity]="bgOpacity"
             [attr.stroke]="strokeColor"

--- a/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
@@ -1,0 +1,47 @@
+import { Component, Input } from '@angular/core';
+import { Transition } from '../models';
+import { environment } from 'src/environments/environment';
+
+@Component({
+    selector: 'svg:g[app-drawing-invisible-transition]',
+    template: `
+        <svg:rect
+            [attr.x]="invisibleTransition.x - width / 2"
+            [attr.y]="invisibleTransition.y - height / 2"
+            [attr.height]="height"
+            [attr.width]="width"
+            [attr.fill]="bgColor"
+            [attr.fill-opacity]="bgOpacity"
+            [attr.stroke]="strokeColor"
+            [attr.stroke-opacity]="strokeOpacity"
+            [attr.stroke-width]="strokeWidth"
+        />
+        <svg:text
+            [attr.x]="invisibleTransition.x"
+            [attr.y]="invisibleTransition.y + (height + strokeWidth) / 2 + 20"
+        >
+            {{ invisibleTransition.name }}
+        </svg:text>
+    `,
+    styles: ``,
+})
+export class DrawingInvisibleTransitionComponent {
+    @Input({ required: true }) invisibleTransition!: Transition;
+
+    readonly height: number =
+        environment.drawingElements.invisibleTransitions.height;
+    readonly width: number =
+        environment.drawingElements.invisibleTransitions.width;
+
+    readonly bgColor: string =
+        environment.drawingElements.invisibleTransitions.bgColor;
+    readonly bgOpacity: string =
+        environment.drawingElements.invisibleTransitions.bgOpacity;
+
+    readonly strokeColor: string =
+        environment.drawingElements.invisibleTransitions.strokeColor;
+    readonly strokeOpacity: string =
+        environment.drawingElements.invisibleTransitions.strokeOpacity;
+    readonly strokeWidth: number =
+        environment.drawingElements.invisibleTransitions.strokeWidth;
+}

--- a/src/app/components/drawing-area/components/drawing-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-transition.component.ts
@@ -25,7 +25,7 @@ import { environment } from 'src/environments/environment';
     `,
     styles: ``,
 })
-export class DrawingTransitionsComponent {
+export class DrawingTransitionComponent {
     @Input({ required: true }) transition!: Transition;
 
     readonly height: number = environment.drawingElements.transitions.height;

--- a/src/app/components/drawing-area/drawing-area.component.html
+++ b/src/app/components/drawing-area/drawing-area.component.html
@@ -29,9 +29,12 @@
                 </ng-container>
             </ng-container>
 
-            <ng-container *ngFor="let transition of transitions">
-                <svg:g app-drawing-transition [transition]="transition"></svg:g>
-            </ng-container>
+        <ng-container *ngFor="let transition of transitions">
+            <svg:g *ngIf="transition.name !== ''; else invisibleTransition" app-drawing-transition [transition]="transition"></svg:g>
+            <ng-template #invisibleTransition>
+                <svg:g app-drawing-invisible-transition [invisibleTransition]="transition"></svg:g>
+            </ng-template>
+        </ng-container>
 
             <ng-container *ngFor="let place of places">
                 <svg:g app-drawing-place [place]="place"></svg:g>

--- a/src/app/components/drawing-area/drawing-area.component.ts
+++ b/src/app/components/drawing-area/drawing-area.component.ts
@@ -10,6 +10,7 @@ import {
     ActivityNode,
     BoxNode,
     Graph,
+    InvisibleTransitionNode,
     PlaceNode,
     TransitionNode,
 } from 'src/app/classes/graph';
@@ -22,6 +23,7 @@ import {
     DfgArc,
     Place,
     PlaceToBoxArc,
+    PlaceToInvisibleTransitionArc,
     PlaceToTransitionArc,
     Transition,
     TransitionToPlaceArc,
@@ -108,9 +110,15 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
                     }
 
                     if (node instanceof TransitionNode) {
-                        transitions.push(
-                            new Transition(node as TransitionNode),
-                        );
+                        if (node instanceof InvisibleTransitionNode) {
+                            transitions.push(
+                                new Transition(node as InvisibleTransitionNode),
+                            );
+                        } else {
+                            transitions.push(
+                                new Transition(node as TransitionNode),
+                            );
+                        }
                     }
 
                     if (node instanceof BoxNode) {
@@ -176,13 +184,23 @@ export class DrawingAreaComponent implements OnInit, OnDestroy {
                                 (transition) =>
                                     transition.id === edge.target.id,
                             )!;
-
-                            arcs.push(
-                                new PlaceToTransitionArc(
-                                    startPlace,
-                                    endTransition,
-                                ),
-                            );
+                            if (
+                                edge.target instanceof InvisibleTransitionNode
+                            ) {
+                                arcs.push(
+                                    new PlaceToInvisibleTransitionArc(
+                                        startPlace,
+                                        endTransition,
+                                    ),
+                                );
+                            } else {
+                                arcs.push(
+                                    new PlaceToTransitionArc(
+                                        startPlace,
+                                        endTransition,
+                                    ),
+                                );
+                            }
                         }
 
                         if (edge.target instanceof BoxNode) {

--- a/src/app/components/drawing-area/drawing-area.module.ts
+++ b/src/app/components/drawing-area/drawing-area.module.ts
@@ -7,10 +7,11 @@ import {
     DrawingArcComponent,
     DrawingBoxArcComponent,
     DrawingPlaceComponent,
-    DrawingTransitionsComponent,
+    DrawingTransitionComponent,
 } from './components';
 import { DrawingBoxComponent } from './components/drawing-box.component';
 import { DrawingAreaComponent } from './drawing-area.component';
+import { DrawingInvisibleTransitionComponent } from './components/drawing-invisible-transition.component';
 
 @NgModule({
     declarations: [
@@ -20,7 +21,8 @@ import { DrawingAreaComponent } from './drawing-area.component';
         DrawingArcComponent,
         DrawingBoxArcComponent,
         DrawingPlaceComponent,
-        DrawingTransitionsComponent,
+        DrawingTransitionComponent,
+        DrawingInvisibleTransitionComponent
     ],
     imports: [CommonModule, MatCheckboxModule, ContextMenuComponent],
     exports: [DrawingAreaComponent],

--- a/src/app/components/drawing-area/models/arcs.ts
+++ b/src/app/components/drawing-area/models/arcs.ts
@@ -68,25 +68,35 @@ export class DfgArc extends Arc {
         heightHalf: number,
         strokeHalf: number,
     ): number {
+        const distanceToRoundedCorner: number = 26;
         const alphaDegAbs = Math.abs(this.alphaDeg);
+        let calculatedLength: number;
         switch (alphaDegAbs) {
             case 0:
-                return widthHalf + strokeHalf;
+                calculatedLength = widthHalf + strokeHalf;
+                break;
             case 45:
-                return Math.sqrt(
+                calculatedLength = Math.sqrt(
                     Math.pow(widthHalf + strokeHalf, 2) +
                         Math.pow(heightHalf + strokeHalf, 2),
                 );
+                break;
             case 90:
-                return heightHalf + strokeHalf;
-
+                calculatedLength = heightHalf + strokeHalf;
+                break;
             default:
+                alphaDegAbs < 45
+                    ? (calculatedLength =
+                          (widthHalf + strokeHalf) /
+                          Math.cos(Math.abs(this.alphaRad)))
+                    : (calculatedLength =
+                          (heightHalf + strokeHalf) /
+                          Math.sin(Math.abs(this.alphaRad)));
                 break;
         }
-
-        return alphaDegAbs < 45
-            ? (widthHalf + strokeHalf) / Math.cos(Math.abs(this.alphaRad))
-            : (heightHalf + strokeHalf) / Math.sin(Math.abs(this.alphaRad));
+        return calculatedLength < distanceToRoundedCorner
+            ? calculatedLength
+            : distanceToRoundedCorner;
     }
 }
 

--- a/src/app/components/drawing-area/models/arcs.ts
+++ b/src/app/components/drawing-area/models/arcs.ts
@@ -189,10 +189,10 @@ export class PlaceToTransitionArc extends Arc {
         const y1 = this.start.y;
 
         const offsetArrow = 5;
-        const widthHalf = environment.drawingElements.activities.width / 2;
-        const heightHalf = environment.drawingElements.activities.height / 2;
+        const widthHalf = environment.drawingElements.transitions.width / 2;
+        const heightHalf = environment.drawingElements.transitions.height / 2;
         const strokeHalf =
-            environment.drawingElements.activities.strokeWidth / 2;
+            environment.drawingElements.transitions.strokeWidth / 2;
 
         let lengthToBorder = this.calculateLengthToTransitionBorder(
             widthHalf,
@@ -234,6 +234,67 @@ export class PlaceToTransitionArc extends Arc {
         return alphaDegAbs < 45
             ? (widthHalf + strokeHalf) / Math.cos(Math.abs(this.alphaRad))
             : (heightHalf + strokeHalf) / Math.sin(Math.abs(this.alphaRad));
+    }
+}
+
+export class PlaceToInvisibleTransitionArc extends Arc {
+    constructor(start: Place, end: Transition) {
+        super(start, end);
+        this.calculateCoordinates();
+    }
+
+    override calculateCoordinates(): void {
+        const x1 = this.start.x;
+        const y1 = this.start.y;
+
+        const offsetArrow = 5;
+        const widthHalf =
+            environment.drawingElements.invisibleTransitions.width / 2;
+        const heightQuarter =
+            environment.drawingElements.invisibleTransitions.height / 4;
+        const strokeHalf =
+            environment.drawingElements.invisibleTransitions.strokeWidth / 2;
+
+        let lengthToBorder = this.calculateLengthToTransitionBorder(
+            widthHalf,
+            heightQuarter,
+            strokeHalf,
+        );
+
+        const realLength = this.length - lengthToBorder - offsetArrow;
+        const deltaX = realLength * Math.cos(Math.abs(this.alphaRad));
+        const deltaY = realLength * Math.sin(Math.abs(this.alphaRad));
+
+        this.x1 = x1;
+        this.x2 = x1 + this.sgnX * deltaX;
+        this.y1 = y1;
+        this.y2 = y1 + this.sgnY * deltaY;
+    }
+
+    private calculateLengthToTransitionBorder(
+        widthHalf: number,
+        heightQuarter: number,
+        strokeHalf: number,
+    ): number {
+        const alphaDegAbs = Math.abs(this.alphaDeg);
+        switch (alphaDegAbs) {
+            case 0:
+                return widthHalf + strokeHalf;
+            case 45:
+                return Math.sqrt(
+                    Math.pow(widthHalf + strokeHalf, 2) +
+                        Math.pow(heightQuarter + strokeHalf, 2),
+                );
+            case 90:
+                return heightQuarter + strokeHalf;
+
+            default:
+                break;
+        }
+
+        return alphaDegAbs < 45
+            ? (widthHalf + strokeHalf) / Math.cos(Math.abs(this.alphaRad))
+            : (heightQuarter + strokeHalf) / Math.sin(Math.abs(this.alphaRad));
     }
 }
 

--- a/src/app/components/drawing-area/models/nodes.ts
+++ b/src/app/components/drawing-area/models/nodes.ts
@@ -64,6 +64,8 @@ export class Transition extends Node {
     }
 }
 
+export class InvisibleTransition extends Transition {}
+
 export class Box extends Node {
     private readonly _width: number;
     private readonly _height: number;
@@ -90,6 +92,8 @@ export class Box extends Node {
     }
 
     get traces(): string[] {
-        return this._eventLog.replaceAll("+", "+###SPLIT###").split('###SPLIT###');
+        return this._eventLog
+            .replaceAll('+', '+###SPLIT###')
+            .split('###SPLIT###');
     }
 }

--- a/src/app/services/calculate-petri-net.service.ts
+++ b/src/app/services/calculate-petri-net.service.ts
@@ -7,6 +7,7 @@ import {
     PetriNetStackElement,
     BoxNode,
     TransitionNode,
+    InvisibleTransitionNode,
 } from '../classes/graph';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Dfg } from '../classes/dfg/dfg';
@@ -296,12 +297,22 @@ export class CalculatePetriNetService {
                 y,
                 graphWithBoxDimension[1],
                 graphWithBoxDimension[2],
-                dfg.eventLog.toString()
+                dfg.eventLog.toString(),
             );
         }
 
         if (stackElement.node instanceof Transition) {
             const transition = stackElement.node as Transition;
+            if (transition.name === '') {
+                return new InvisibleTransitionNode(
+                    transition.id,
+                    stackElement.source_x +
+                        gapX +
+                        stackElement.additionalXOffset,
+                    yCoordinate,
+                    transition.name,
+                );
+            }
             return new TransitionNode(
                 transition.id,
                 stackElement.source_x + gapX + stackElement.additionalXOffset,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,6 +8,7 @@ export const environment = {
         activities: {
             width: 40,
             height: 40,
+            radius: 7,
             bgColor: 'white',
             bgOpacity: '1',
             strokeColor: 'black',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -30,6 +30,15 @@ export const environment = {
             strokeOpacity: '1',
             strokeWidth: 2,
         },
+        invisibleTransitions: {
+            width: 20,
+            height: 40,
+            bgColor: 'black',
+            bgOpacity: '1',
+            strokeColor: 'black',
+            strokeOpacity: '1',
+            strokeWidth: 2,
+        },
         places: {
             radius: 20,
             bgColor: 'white',


### PR DESCRIPTION
Die Kanten werden bei veränderter Optik der Elemente nicht mehr bis zu deren Rand gezeichnet. Mir ist allerdings nicht so ganz klar wie die Kanten genau berechnet werden. Daher die Frage an die Front-End-Profis, ist das großer Aufwand das anzupassen?
![ksnip_20250122-164914](https://github.com/user-attachments/assets/46f90b91-5eb5-47e4-9856-9c084058e2e9)
