### PR TITLE
SCRUM-65-ueberschneidende-Arcs-im-Petri-Netz-als-Boegen-darstellen

### DIFF
--- a/src/app/components/drawing-area/components/drawing-arc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-arc.component.ts
@@ -3,6 +3,7 @@ import { Arc } from '../models';
 import { environment } from 'src/environments/environment';
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
+import { PetriNetManagementService } from 'src/app/services/petri-net-management.service';
 
 @Component({
     selector: 'svg:g[app-drawing-arc]',
@@ -81,6 +82,7 @@ export class DrawingArcComponent {
     constructor(
         private collectSelectedElementsService: CollectSelectedElementsService,
         private feedbackService: ShowFeedbackService,
+        private petriNetManagementService: PetriNetManagementService,
     ) {}
 
     readonly width: number = environment.drawingElements.arcs.width;
@@ -222,6 +224,9 @@ export class DrawingArcComponent {
     }
 
     private pathNecessary(arc: Arc): boolean {
-        return this.collectSelectedElementsService.overlayArcsExistsInDFGs(arc);
+        return (
+            this.collectSelectedElementsService.isOverlayedArcInDFG(arc) ||
+            this.petriNetManagementService.arcIsOverlayingArc(arc)
+        );
     }
 }

--- a/src/app/services/collect-selected-elements.service.ts
+++ b/src/app/services/collect-selected-elements.service.ts
@@ -223,7 +223,7 @@ export class CollectSelectedElementsService {
         return false;
     }
 
-    public overlayArcsExistsInDFGs(arc: Arc): boolean {
+    public isOverlayedArcInDFG(arc: Arc): boolean {
         const dfgOfArc = this.getDFG(arc);
 
         if (dfgOfArc) {

--- a/src/app/services/petri-net-management.service.ts
+++ b/src/app/services/petri-net-management.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { Dfg } from '../classes/dfg/dfg';
 import { ShowFeedbackService } from './show-feedback.service';
 import _ from 'lodash';
+import { Arc } from '../components/drawing-area/models';
 
 @Injectable({
     providedIn: 'root',
@@ -122,5 +123,19 @@ export class PetriNetManagementService {
 
     get isInputPetriNet(): boolean {
         return this._isInputPetriNet;
+    }
+
+    public arcIsOverlayingArc(arc: Arc): boolean {
+        const overlayArc = this._petriNet.arcs.arcs.filter(
+            (arcInPetriNet) =>
+                arcInPetriNet.start.id === arc.end.id &&
+                arcInPetriNet.end.id === arc.start.id,
+        );
+
+        if (overlayArc.length > 0) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Überschneidene Arcs in Petri-Netzen werden nun auch als Bögen dargestellt.