### PR TITLE
SCRUM-96-Kanten-die-einen-Loop-auf-sich-selbst-bilden-sollen-dargestellt-werden

### DIFF
--- a/src/app/components/drawing-area/components/drawing-loop-arc.components.ts
+++ b/src/app/components/drawing-area/components/drawing-loop-arc.components.ts
@@ -1,0 +1,48 @@
+import { Component, Input } from '@angular/core';
+import { environment } from 'src/environments/environment';
+import { Arc } from '../models';
+
+@Component({
+    selector: 'svg:g[app-drawing-loop-arc]',
+    template: `
+        <svg:defs>
+            <svg:marker
+                id="arrowhead"
+                viewBox="0 0 10 10"
+                markerWidth="10"
+                markerHeight="10"
+                refX="5"
+                refY="5"
+                orient="auto-start-reverse"
+            >
+                <svg:path
+                    d="M 1,1 L 9,5 L 1,9 Z"
+                    [attr.fill]="color"
+                    [attr.stroke]="color"
+                    [attr.stroke-width]="width"
+                ></svg:path>
+            </svg:marker>
+        </svg:defs>
+
+        <svg:path
+            [attr.d]="setPath(loopArc)"
+            [attr.stroke]="'black'"
+            [attr.stroke-width]="width"
+            [attr.fill]="'none'"
+            marker-end="url(#arrowhead)"
+        ></svg:path>
+    `,
+    styles: ``,
+})
+export class DrawingLoopArcComponent {
+    @Input({ required: true }) loopArc!: Arc;
+
+    constructor() {}
+
+    readonly width: number = environment.drawingElements.arcs.width;
+    readonly color: string = environment.drawingElements.arcs.color;
+
+    setPath(arc: Arc): string {
+        return `M ${arc.x1 - 15} ${arc.y1 - 12} A 25 15 0 1 1 ${arc.x1 + 18} ${arc.y1 - 14}`;
+    }
+}

--- a/src/app/components/drawing-area/drawing-area.component.html
+++ b/src/app/components/drawing-area/drawing-area.component.html
@@ -1,48 +1,59 @@
 <div (contextmenu)="onContextMenu($event)" (click)="onMenuClose()">
     <div id="drawingArea">
-            <svg
-                (mousedown)="mouseDown()"
-                (mouseup)="mouseUp()"
-                id="svg"
-                #svgElement
-                xmlns="http://www.w3.org/2000/svg"
-            >
-                <ng-container *ngFor="let arc of arcs">
-                    <svg:g app-drawing-arc [arc]="arc"></svg:g>
-                </ng-container>
+        <svg
+            (mousedown)="mouseDown()"
+            (mouseup)="mouseUp()"
+            id="svg"
+            #svgElement
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <ng-container *ngFor="let arc of arcs">
+                <svg:g app-drawing-arc [arc]="arc"></svg:g>
+            </ng-container>
 
-                <ng-container *ngFor="let box of boxes">
-                    <svg:g
-                        app-drawing-box
-                        [box]="box"
-                        [showEventLogs]="showEventLogs"
-                    ></svg:g>
-                </ng-container>
+            <ng-container *ngFor="let box of boxes">
+                <svg:g
+                    app-drawing-box
+                    [box]="box"
+                    [showEventLogs]="showEventLogs"
+                ></svg:g>
+            </ng-container>
 
             <ng-container *ngIf="!showEventLogs">
                 <ng-container *ngFor="let boxArc of boxArcs">
-                    <svg:g app-drawing-boxArc [boxArc]="boxArc"></svg:g>
+                    <svg:g
+                        *ngIf="boxArc.start !== boxArc.end; else loopArc"
+                        app-drawing-boxArc
+                        [boxArc]="boxArc"
+                    ></svg:g>
+                    <ng-template #loopArc>
+                        <svg:g app-drawing-loop-arc [loopArc]="boxArc"></svg:g>
+                    </ng-template>
                 </ng-container>
 
-                    <ng-container *ngFor="let activity of activities">
-                        <svg:g
-                            app-drawing-activity
-                            [activity]="activity"
-                        ></svg:g>
-                    </ng-container>
+                <ng-container *ngFor="let activity of activities">
+                    <svg:g app-drawing-activity [activity]="activity"></svg:g>
                 </ng-container>
+            </ng-container>
 
-        <ng-container *ngFor="let transition of transitions">
-            <svg:g *ngIf="transition.name !== ''; else invisibleTransition" app-drawing-transition [transition]="transition"></svg:g>
-            <ng-template #invisibleTransition>
-                <svg:g app-drawing-invisible-transition [invisibleTransition]="transition"></svg:g>
-            </ng-template>
-        </ng-container>
+            <ng-container *ngFor="let transition of transitions">
+                <svg:g
+                    *ngIf="transition.name !== ''; else invisibleTransition"
+                    app-drawing-transition
+                    [transition]="transition"
+                ></svg:g>
+                <ng-template #invisibleTransition>
+                    <svg:g
+                        app-drawing-invisible-transition
+                        [invisibleTransition]="transition"
+                    ></svg:g>
+                </ng-template>
+            </ng-container>
 
-                <ng-container *ngFor="let place of places">
-                    <svg:g app-drawing-place [place]="place"></svg:g>
-                </ng-container>
-            </svg>
+            <ng-container *ngFor="let place of places">
+                <svg:g app-drawing-place [place]="place"></svg:g>
+            </ng-container>
+        </svg>
         <div class="start-text" *ngIf="isEmpty">Right click here to start.</div>
     </div>
 </div>

--- a/src/app/components/drawing-area/drawing-area.module.ts
+++ b/src/app/components/drawing-area/drawing-area.module.ts
@@ -12,6 +12,7 @@ import {
 import { DrawingBoxComponent } from './components/drawing-box.component';
 import { DrawingAreaComponent } from './drawing-area.component';
 import { DrawingInvisibleTransitionComponent } from './components/drawing-invisible-transition.component';
+import { DrawingLoopArcComponent } from './components/drawing-loop-arc.components';
 
 @NgModule({
     declarations: [
@@ -22,7 +23,8 @@ import { DrawingInvisibleTransitionComponent } from './components/drawing-invisi
         DrawingBoxArcComponent,
         DrawingPlaceComponent,
         DrawingTransitionComponent,
-        DrawingInvisibleTransitionComponent
+        DrawingInvisibleTransitionComponent,
+        DrawingLoopArcComponent
     ],
     imports: [CommonModule, MatCheckboxModule, ContextMenuComponent],
     exports: [DrawingAreaComponent],


### PR DESCRIPTION
Direkt aufeinander folgende gleiche Aktivitäten im Eventlog erzeugen einen Loop auf sich selbst. Diese werden jetzt dargestellt.

Die Auflösung dieser Loops um das Log komplett zu zerlegen erfolgt durch ein Flower Model FT. Deswegen ist die Loop-Kante auch nicht clickbar. Außerdem kann ja bei so einem Loop keine Partitionierung erfolgen, womit ich es auch nachvollziehbar finde, dass es nicht als Cut gilt.

Außerdem schein dieses Verhalten viel weniger ausgeprägt zu sein als ich angenommen hatte (@haiddablitz hatte es schon geahnt). Nach der Filterung von Lifecycles treten in den großen Logs keine Loops auf. Aber da es trotzdem möglich ist, dass User das eingeben ist es hiermit berücksichtigt.