### PR TITLE
SCRUM-100-Elemente-im-Petri-Netz-ebenfalls-ziehbar-machen

### DIFF
--- a/src/app/components/drawing-area/components/drawing-activity.component.ts
+++ b/src/app/components/drawing-area/components/drawing-activity.component.ts
@@ -174,7 +174,7 @@ export class DrawingActivityComponent {
                     }
                 }
 
-                this._positionForActivitiesService.updatePosition(
+                this._positionForActivitiesService.updateActivityPosition(
                     this.activity.id,
                     this.activity.dfgId,
                     dx,
@@ -192,7 +192,7 @@ export class DrawingActivityComponent {
                 mousePositionCurrent[0] !== this.mousePositionInitial[0] &&
                 mousePositionCurrent[1] !== this.mousePositionInitial[1]
             ) {
-                this._positionForActivitiesService.updateCoordinatesOfArcs(
+                this._positionForActivitiesService.updateCoordinatesOfBoxArcs(
                     this.activity.id,
                     this.activity.dfgId,
                     this.activity.x,

--- a/src/app/components/drawing-area/components/drawing-box.component.ts
+++ b/src/app/components/drawing-area/components/drawing-box.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { environment } from 'src/environments/environment';
 import { Box } from '../models';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
 
 @Component({
     selector: 'svg:g[app-drawing-box]',
@@ -17,7 +18,11 @@ import { Box } from '../models';
             [attr.stroke-opacity]="strokeOpacity"
             [attr.stroke-width]="strokeWidth"
             pointer-events="stroke"
-            (click)="onBoxClick($event, box)"
+            [classList]="'draggable confine'"
+            (mousedown)="startDrag($event)"
+            (mousemove)="drag($event)"
+            (mouseup)="endDrag($event, box)"
+            (mouseleave)="endDrag($event, box)"
         />
         <svg:text
             [attr.x]="box.x - box.id.length * 4.8"
@@ -62,6 +67,9 @@ import { Box } from '../models';
                 background-color: #efc9db;
             }
         }
+        .draggable {
+            cursor: move;
+        }
     `,
 })
 export class DrawingBoxComponent {
@@ -70,6 +78,7 @@ export class DrawingBoxComponent {
 
     constructor(
         private _collectSelectedElementsService: CollectSelectedElementsService,
+        private _positionForActivitiesService: PositionForActivitiesService,
     ) {}
 
     readonly bgColor: string = environment.drawingElements.boxes.bgColor;
@@ -82,21 +91,137 @@ export class DrawingBoxComponent {
     readonly strokeWidth: number =
         environment.drawingElements.boxes.strokeWidth;
 
-    onBoxClick(event: Event, box: Box) {
-        const rect = event.target as SVGRectElement;
+    elementSelected: any;
+    offset: any;
+    transform: any;
+    mousePositionInitial: [number, number] = [0, 0];
+    mouseClicked: boolean = false;
+
+    dx: number = 0;
+    dy: number = 0;
+
+    // onBoxClick(event: Event, box: Box) {
+    //     const rect = event.target as SVGRectElement;
+    //     const svg: SVGSVGElement = document.getElementsByTagName(
+    //         'svg',
+    //     )[0] as SVGSVGElement;
+    //     if (svg) {
+    //         const boxes = svg.querySelectorAll('rect');
+    //         boxes.forEach((box) => {
+    //             if (rect === box) {
+    //                 rect.classList.toggle('box-marked');
+    //             } else {
+    //                 box.classList.remove('box-marked');
+    //             }
+    //         });
+    //     }
+    //     this._collectSelectedElementsService.updateSelectedDFG(box.id);
+    // }
+
+    startDrag(event: MouseEvent) {
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
         )[0] as SVGSVGElement;
-        if (svg) {
-            const boxes = svg.querySelectorAll('rect');
-            boxes.forEach((box) => {
-                if (rect === box) {
-                    rect.classList.toggle('box-marked');
-                } else {
-                    box.classList.remove('box-marked');
-                }
-            });
+        const target = event.target as SVGRectElement;
+        this.mouseClicked = true;
+        this.mousePositionInitial = [event.clientX, event.clientY];
+
+        if (target.classList.contains('draggable')) {
+            this.offset = this.getMousePosition(event);
+            this.elementSelected = target;
+
+            const transforms = this.elementSelected.transform.baseVal;
+
+            if (
+                transforms.length === 0 ||
+                transforms.getItem(0).type !==
+                    SVGTransform.SVG_TRANSFORM_TRANSLATE
+            ) {
+                const translate = svg.createSVGTransform();
+                translate.setTranslate(0, 0);
+
+                this.elementSelected.transform.baseVal.insertItemBefore(
+                    translate,
+                    0,
+                );
+            }
+
+            this.transform = transforms.getItem(0);
+            this.offset.x -= this.transform.matrix.e;
+            this.offset.y -= this.transform.matrix.f;
         }
-        this._collectSelectedElementsService.updateSelectedDFG(box.id);
+    }
+    drag(event: MouseEvent) {
+        const target = event.target as SVGRectElement;
+        if (this.elementSelected !== null && this.mouseClicked === true) {
+            event.preventDefault();
+            const coord = this.getMousePosition(event);
+
+            if (this.transform !== undefined) {
+                this.dx = coord.x - this.offset.x;
+                this.dy = coord.y - this.offset.y;
+
+                this._positionForActivitiesService.updateElementPosition(
+                    this.box.id,
+                    'box',
+                    this.dx,
+                    this.dy,
+                );
+            }
+        }
+    }
+    endDrag(event: MouseEvent, box: Box) {
+        this.elementSelected = null;
+        const mousePositionCurrent = [event.clientX, event.clientY];
+
+        if (this.mouseClicked) {
+            if (
+                mousePositionCurrent[0] !== this.mousePositionInitial[0] &&
+                mousePositionCurrent[1] !== this.mousePositionInitial[1]
+            ) {
+                this._positionForActivitiesService.updateEndPositionOfElement(
+                    this.box.id,
+                    'box',
+                    this.box.x,
+                    this.box.y,
+                    this.dx,
+                    this.dy,
+                );
+                this.mouseClicked = false;
+            } else {
+                const rect = event.target as SVGRectElement;
+                const svg: SVGSVGElement = document.getElementsByTagName(
+                    'svg',
+                )[0] as SVGSVGElement;
+                if (svg) {
+                    const boxes = svg.querySelectorAll('rect');
+                    boxes.forEach((box) => {
+                        if (rect === box) {
+                            rect.classList.toggle('box-marked');
+                        } else {
+                            box.classList.remove('box-marked');
+                        }
+                    });
+                }
+                this._collectSelectedElementsService.updateSelectedDFG(box.id);
+                this.mouseClicked = false;
+            }
+        }
+    }
+
+    private getMousePosition(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        var CTM = svg.getScreenCTM();
+
+        if (!CTM) {
+            throw new Error('CTM is null');
+        }
+
+        return {
+            x: (event.clientX - CTM.e) / CTM.a,
+            y: (event.clientY - CTM.f) / CTM.d,
+        };
     }
 }

--- a/src/app/components/drawing-area/components/drawing-boxArc.component.ts
+++ b/src/app/components/drawing-area/components/drawing-boxArc.component.ts
@@ -4,8 +4,6 @@ import { environment } from 'src/environments/environment';
 import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 import { ShowFeedbackService } from 'src/app/services/show-feedback.service';
 import { PetriNetManagementService } from 'src/app/services/petri-net-management.service';
-import { Subscription } from 'rxjs';
-import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
 
 @Component({
     selector: 'svg:g[app-drawing-boxArc]',
@@ -85,40 +83,11 @@ export class DrawingBoxArcComponent {
         private collectSelectedElementsService: CollectSelectedElementsService,
         private feedbackService: ShowFeedbackService,
         private petriNetManagementService: PetriNetManagementService,
-        private positionForActivitiesService: PositionForActivitiesService,
     ) {}
 
     readonly width: number = environment.drawingElements.arcs.width;
     readonly color: string = environment.drawingElements.arcs.color;
     private timeoutId: any;
-
-    private _sub: Subscription | undefined;
-    private _sub2: Subscription | undefined;
-
-    private movingActivityID: string = '';
-    private xTranslate = 0;
-    private yTranslate = 0;
-    private movedActivityIdToSetNewCoordinates: string = '';
-    private updateCoordinates = false;
-
-    ngOnInit(): void {
-        this._sub =
-            this.positionForActivitiesService.movingActivityInGraph$.subscribe(
-                (position) => {
-                    this.movingActivityID = position[0];
-                    this.xTranslate = position[2];
-                    this.yTranslate = position[3];
-                },
-            );
-
-        this._sub2 =
-            this.positionForActivitiesService.updateArcCoordinates$.subscribe(
-                (coordinate) => {
-                    this.movedActivityIdToSetNewCoordinates = coordinate[0];
-                    this.updateCoordinates = true;
-                },
-            );
-    }
 
     changeLineColorOver(event: Event, arc: Arc): void {
         const pathDummy = event.target as SVGPathElement;

--- a/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
@@ -67,6 +67,18 @@ export class DrawingInvisibleTransitionComponent {
     dx: number = 0;
     dy: number = 0;
 
+    bbox: any;
+
+    boundaryX1: number = 0;
+    boundaryX2: number = 0;
+    boundaryY1: number = 0;
+    boundaryY2: number = 0;
+
+    minX: number = 0;
+    maxX: number = 0;
+    minY: number = 0;
+    maxY: number = 0;
+
     startDrag(event: MouseEvent) {
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
@@ -74,11 +86,21 @@ export class DrawingInvisibleTransitionComponent {
         const target = event.target as SVGRectElement;
         this.mouseClicked = true;
 
+        this.setBoundary(svg);
+
         if (target.classList.contains('draggable')) {
             this.offset = this.getMousePosition(event);
             this.elementSelected = target;
 
             const transforms = this.elementSelected.transform.baseVal;
+
+            if (target.classList.contains('confine')) {
+                this.bbox = target.getBBox();
+                this.minX = this.boundaryX1 - this.bbox.x;
+                this.maxX = this.boundaryX2 - this.bbox.x - this.bbox.width;
+                this.minY = this.boundaryY1 - this.bbox.y;
+                this.maxY = this.boundaryY2 - this.bbox.y - this.bbox.height;
+            }
 
             if (
                 transforms.length === 0 ||
@@ -110,19 +132,19 @@ export class DrawingInvisibleTransitionComponent {
                 this.dx = coord.x - this.offset.x;
                 this.dy = coord.y - this.offset.y;
 
-                // if (target.classList.contains('confine')) {
-                //     if (dx < this.minX) {
-                //         dx = this.minX;
-                //     } else if (dx > this.maxX) {
-                //         dx = this.maxX;
-                //     }
+                if (target.classList.contains('confine')) {
+                    if (this.dx < this.minX) {
+                        this.dx = this.minX;
+                    } else if (this.dx > this.maxX) {
+                        this.dx = this.maxX;
+                    }
 
-                //     if (dy < this.minY) {
-                //         dy = this.minY;
-                //     } else if (dy > this.maxY) {
-                //         dy = this.maxY;
-                //     }
-                // }
+                    if (this.dy < this.minY) {
+                        this.dy = this.minY;
+                    } else if (this.dy > this.maxY) {
+                        this.dy = this.maxY;
+                    }
+                }
 
                 this._positionForActivitiesService.updateElementPosition(
                     this.invisibleTransition.id,
@@ -163,5 +185,24 @@ export class DrawingInvisibleTransitionComponent {
             x: (event.clientX - CTM.e) / CTM.a,
             y: (event.clientY - CTM.f) / CTM.d,
         };
+    }
+
+    private setBoundary(svg: SVGSVGElement): void {
+        const drawingArea = document.getElementById('drawingArea');
+        if (drawingArea && svg) {
+            const drawingAreaBox = drawingArea.getBoundingClientRect();
+            const svgBox = svg.getBoundingClientRect();
+
+            this.boundaryX2 = drawingAreaBox.width;
+            this.boundaryY2 = drawingAreaBox.height;
+
+            if (svgBox.width > drawingAreaBox.width) {
+                this.boundaryX2 = svgBox.width;
+            }
+
+            if (svgBox.height > drawingAreaBox.height) {
+                this.boundaryY2 = svgBox.height;
+            }
+        }
     }
 }

--- a/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { Transition } from '../models';
 import { environment } from 'src/environments/environment';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
 
 @Component({
     selector: 'svg:g[app-drawing-invisible-transition]',
@@ -15,6 +16,11 @@ import { environment } from 'src/environments/environment';
             [attr.stroke]="strokeColor"
             [attr.stroke-opacity]="strokeOpacity"
             [attr.stroke-width]="strokeWidth"
+            [classList]="'draggable confine'"
+            (mousedown)="startDrag($event)"
+            (mousemove)="drag($event)"
+            (mouseup)="endDrag($event, invisibleTransition)"
+            (mouseleave)="endDrag($event, invisibleTransition)"
         />
         <svg:text
             [attr.x]="invisibleTransition.x"
@@ -23,10 +29,18 @@ import { environment } from 'src/environments/environment';
             {{ invisibleTransition.name }}
         </svg:text>
     `,
-    styles: ``,
+    styles: `
+        rect:hover {
+            cursor: move;
+        }
+    `,
 })
 export class DrawingInvisibleTransitionComponent {
     @Input({ required: true }) invisibleTransition!: Transition;
+
+    constructor(
+        private _positionForActivitiesService: PositionForActivitiesService,
+    ) {}
 
     readonly height: number =
         environment.drawingElements.invisibleTransitions.height;
@@ -44,4 +58,105 @@ export class DrawingInvisibleTransitionComponent {
         environment.drawingElements.invisibleTransitions.strokeOpacity;
     readonly strokeWidth: number =
         environment.drawingElements.invisibleTransitions.strokeWidth;
+
+    mouseClicked: boolean = false;
+    offset: any;
+    transform: any;
+    elementSelected: any;
+
+    startDrag(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        const target = event.target as SVGRectElement;
+        this.mouseClicked = true;
+
+        if (target.classList.contains('draggable')) {
+            this.offset = this.getMousePosition(event);
+            this.elementSelected = target;
+
+            const transforms = this.elementSelected.transform.baseVal;
+
+            if (
+                transforms.length === 0 ||
+                transforms.getItem(0).type !==
+                    SVGTransform.SVG_TRANSFORM_TRANSLATE
+            ) {
+                const translate = svg.createSVGTransform();
+                translate.setTranslate(0, 0);
+
+                this.elementSelected.transform.baseVal.insertItemBefore(
+                    translate,
+                    0,
+                );
+            }
+
+            this.transform = transforms.getItem(0);
+            this.offset.x -= this.transform.matrix.e;
+            this.offset.y -= this.transform.matrix.f;
+        }
+    }
+
+    drag(event: MouseEvent) {
+        const target = event.target as SVGRectElement;
+        if (this.elementSelected !== null && this.mouseClicked === true) {
+            event.preventDefault();
+            const coord = this.getMousePosition(event);
+
+            if (this.transform !== undefined) {
+                let dx = coord.x - this.offset.x;
+                let dy = coord.y - this.offset.y;
+
+                // if (target.classList.contains('confine')) {
+                //     if (dx < this.minX) {
+                //         dx = this.minX;
+                //     } else if (dx > this.maxX) {
+                //         dx = this.maxX;
+                //     }
+
+                //     if (dy < this.minY) {
+                //         dy = this.minY;
+                //     } else if (dy > this.maxY) {
+                //         dy = this.maxY;
+                //     }
+                // }
+
+                this._positionForActivitiesService.updateElementPosition(
+                    this.invisibleTransition.id,
+                    'transition',
+                    dx,
+                    dy,
+                );
+            }
+        }
+    }
+
+    endDrag(event: MouseEvent, pltransitionace: Transition) {
+        this.elementSelected = null;
+        if (this.mouseClicked) {
+            this._positionForActivitiesService.updateEndPositionOfElement(
+                this.invisibleTransition.id,
+                'transition',
+                this.invisibleTransition.x,
+                this.invisibleTransition.y,
+            );
+            this.mouseClicked = false;
+        }
+    }
+
+    private getMousePosition(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        var CTM = svg.getScreenCTM();
+
+        if (!CTM) {
+            throw new Error('CTM is null');
+        }
+
+        return {
+            x: (event.clientX - CTM.e) / CTM.a,
+            y: (event.clientY - CTM.f) / CTM.d,
+        };
+    }
 }

--- a/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-invisible-transition.component.ts
@@ -64,6 +64,9 @@ export class DrawingInvisibleTransitionComponent {
     transform: any;
     elementSelected: any;
 
+    dx: number = 0;
+    dy: number = 0;
+
     startDrag(event: MouseEvent) {
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
@@ -104,8 +107,8 @@ export class DrawingInvisibleTransitionComponent {
             const coord = this.getMousePosition(event);
 
             if (this.transform !== undefined) {
-                let dx = coord.x - this.offset.x;
-                let dy = coord.y - this.offset.y;
+                this.dx = coord.x - this.offset.x;
+                this.dy = coord.y - this.offset.y;
 
                 // if (target.classList.contains('confine')) {
                 //     if (dx < this.minX) {
@@ -124,8 +127,8 @@ export class DrawingInvisibleTransitionComponent {
                 this._positionForActivitiesService.updateElementPosition(
                     this.invisibleTransition.id,
                     'transition',
-                    dx,
-                    dy,
+                    this.dx,
+                    this.dy,
                 );
             }
         }
@@ -139,6 +142,8 @@ export class DrawingInvisibleTransitionComponent {
                 'transition',
                 this.invisibleTransition.x,
                 this.invisibleTransition.y,
+                this.dx,
+                this.dy,
             );
             this.mouseClicked = false;
         }

--- a/src/app/components/drawing-area/components/drawing-place.component.ts
+++ b/src/app/components/drawing-area/components/drawing-place.component.ts
@@ -68,6 +68,9 @@ export class DrawingPlaceComponent {
     transform: any;
     elementSelected: any;
 
+    dx: number = 0;
+    dy: number = 0;
+
     minX: number = 0;
     maxX: number = 0;
     minY: number = 0;
@@ -113,8 +116,8 @@ export class DrawingPlaceComponent {
             const coord = this.getMousePosition(event);
 
             if (this.transform !== undefined) {
-                let dx = coord.x - this.offset.x;
-                let dy = coord.y - this.offset.y;
+                this.dx = coord.x - this.offset.x;
+                this.dy = coord.y - this.offset.y;
 
                 // if (target.classList.contains('confine')) {
                 //     if (dx < this.minX) {
@@ -133,8 +136,8 @@ export class DrawingPlaceComponent {
                 this._positionForActivitiesService.updateElementPosition(
                     this.place.id,
                     'place',
-                    dx,
-                    dy,
+                    this.dx,
+                    this.dy,
                 );
             }
         }
@@ -148,6 +151,8 @@ export class DrawingPlaceComponent {
                 'place',
                 this.place.x,
                 this.place.y,
+                this.dx,
+                this.dy,
             );
             this.mouseClicked = false;
         }

--- a/src/app/components/drawing-area/components/drawing-place.component.ts
+++ b/src/app/components/drawing-area/components/drawing-place.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { Place } from '../models';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
+import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 
 @Component({
     selector: 'svg:g[app-drawing-place]',
@@ -19,6 +21,11 @@ import { Place } from '../models';
             [attr.stroke]="strokeColor"
             [attr.stroke-opacity]="strokeOpacity"
             [attr.stroke-width]="strokeWidth"
+            [classList]="'draggable confine'"
+            (mousedown)="startDrag($event)"
+            (mousemove)="drag($event)"
+            (mouseup)="endDrag($event, place)"
+            (mouseleave)="endDrag($event, place)"
         />
         <svg:text
             [attr.x]="place.x - place.id.length * 4.8"
@@ -31,10 +38,18 @@ import { Place } from '../models';
         circle {
             fill: black;
         }
+        ellipse:hover {
+            cursor: move;
+        }
     `,
 })
 export class DrawingPlaceComponent {
     @Input({ required: true }) place!: Place;
+
+    constructor(
+        private _collectSelectedElementsService: CollectSelectedElementsService,
+        private _positionForActivitiesService: PositionForActivitiesService,
+    ) {}
 
     readonly radius: number = environment.drawingElements.places.radius;
 
@@ -47,4 +62,110 @@ export class DrawingPlaceComponent {
         environment.drawingElements.places.strokeOpacity;
     readonly strokeWidth: number =
         environment.drawingElements.places.strokeWidth;
+
+    mouseClicked: boolean = false;
+    offset: any;
+    transform: any;
+    elementSelected: any;
+
+    minX: number = 0;
+    maxX: number = 0;
+    minY: number = 0;
+    maxY: number = 0;
+
+    startDrag(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        const target = event.target as SVGRectElement;
+        this.mouseClicked = true;
+
+        if (target.classList.contains('draggable')) {
+            this.offset = this.getMousePosition(event);
+            this.elementSelected = target;
+
+            const transforms = this.elementSelected.transform.baseVal;
+
+            if (
+                transforms.length === 0 ||
+                transforms.getItem(0).type !==
+                    SVGTransform.SVG_TRANSFORM_TRANSLATE
+            ) {
+                const translate = svg.createSVGTransform();
+                translate.setTranslate(0, 0);
+
+                this.elementSelected.transform.baseVal.insertItemBefore(
+                    translate,
+                    0,
+                );
+            }
+
+            this.transform = transforms.getItem(0);
+            this.offset.x -= this.transform.matrix.e;
+            this.offset.y -= this.transform.matrix.f;
+        }
+    }
+
+    drag(event: MouseEvent) {
+        const target = event.target as SVGRectElement;
+        if (this.elementSelected !== null && this.mouseClicked === true) {
+            event.preventDefault();
+            const coord = this.getMousePosition(event);
+
+            if (this.transform !== undefined) {
+                let dx = coord.x - this.offset.x;
+                let dy = coord.y - this.offset.y;
+
+                // if (target.classList.contains('confine')) {
+                //     if (dx < this.minX) {
+                //         dx = this.minX;
+                //     } else if (dx > this.maxX) {
+                //         dx = this.maxX;
+                //     }
+
+                //     if (dy < this.minY) {
+                //         dy = this.minY;
+                //     } else if (dy > this.maxY) {
+                //         dy = this.maxY;
+                //     }
+                // }
+
+                this._positionForActivitiesService.updateElementPosition(
+                    this.place.id,
+                    'place',
+                    dx,
+                    dy,
+                );
+            }
+        }
+    }
+
+    endDrag(event: MouseEvent, place: Place) {
+        this.elementSelected = null;
+        if (this.mouseClicked) {
+            this._positionForActivitiesService.updateEndPositionOfElement(
+                this.place.id,
+                'place',
+                this.place.x,
+                this.place.y,
+            );
+            this.mouseClicked = false;
+        }
+    }
+
+    private getMousePosition(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        var CTM = svg.getScreenCTM();
+
+        if (!CTM) {
+            throw new Error('CTM is null');
+        }
+
+        return {
+            x: (event.clientX - CTM.e) / CTM.a,
+            y: (event.clientY - CTM.f) / CTM.d,
+        };
+    }
 }

--- a/src/app/components/drawing-area/components/drawing-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-transition.component.ts
@@ -62,6 +62,9 @@ export class DrawingTransitionComponent {
     transform: any;
     elementSelected: any;
 
+    dx: number = 0;
+    dy: number = 0;
+
     startDrag(event: MouseEvent) {
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
@@ -102,8 +105,8 @@ export class DrawingTransitionComponent {
             const coord = this.getMousePosition(event);
 
             if (this.transform !== undefined) {
-                let dx = coord.x - this.offset.x;
-                let dy = coord.y - this.offset.y;
+                this.dx = coord.x - this.offset.x;
+                this.dy = coord.y - this.offset.y;
 
                 // if (target.classList.contains('confine')) {
                 //     if (dx < this.minX) {
@@ -122,8 +125,8 @@ export class DrawingTransitionComponent {
                 this._positionForActivitiesService.updateElementPosition(
                     this.transition.id,
                     'transition',
-                    dx,
-                    dy,
+                    this.dx,
+                    this.dy,
                 );
             }
         }
@@ -137,6 +140,8 @@ export class DrawingTransitionComponent {
                 'transition',
                 this.transition.x,
                 this.transition.y,
+                this.dx,
+                this.dy,
             );
             this.mouseClicked = false;
         }

--- a/src/app/components/drawing-area/components/drawing-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-transition.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { Transition } from '../models';
+import { PositionForActivitiesService } from 'src/app/services/position-for-activities.service';
+import { CollectSelectedElementsService } from 'src/app/services/collect-selected-elements.service';
 
 @Component({
     selector: 'svg:g[app-drawing-transition]',
@@ -15,6 +17,11 @@ import { Transition } from '../models';
             [attr.stroke]="strokeColor"
             [attr.stroke-opacity]="strokeOpacity"
             [attr.stroke-width]="strokeWidth"
+            [classList]="'draggable confine'"
+            (mousedown)="startDrag($event)"
+            (mousemove)="drag($event)"
+            (mouseup)="endDrag($event, transition)"
+            (mouseleave)="endDrag($event, transition)"
         />
         <svg:text
             [attr.x]="transition.x - transition.name.length * 4.8"
@@ -23,10 +30,18 @@ import { Transition } from '../models';
             {{ transition.name }}
         </svg:text>
     `,
-    styles: ``,
+    styles: `
+        rect:hover {
+            cursor: move;
+        }
+    `,
 })
 export class DrawingTransitionComponent {
     @Input({ required: true }) transition!: Transition;
+    constructor(
+        private _collectSelectedElementsService: CollectSelectedElementsService,
+        private _positionForActivitiesService: PositionForActivitiesService,
+    ) {}
 
     readonly height: number = environment.drawingElements.transitions.height;
     readonly width: number = environment.drawingElements.transitions.height;
@@ -41,4 +56,105 @@ export class DrawingTransitionComponent {
         environment.drawingElements.transitions.strokeOpacity;
     readonly strokeWidth: number =
         environment.drawingElements.transitions.strokeWidth;
+
+    mouseClicked: boolean = false;
+    offset: any;
+    transform: any;
+    elementSelected: any;
+
+    startDrag(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        const target = event.target as SVGRectElement;
+        this.mouseClicked = true;
+
+        if (target.classList.contains('draggable')) {
+            this.offset = this.getMousePosition(event);
+            this.elementSelected = target;
+
+            const transforms = this.elementSelected.transform.baseVal;
+
+            if (
+                transforms.length === 0 ||
+                transforms.getItem(0).type !==
+                    SVGTransform.SVG_TRANSFORM_TRANSLATE
+            ) {
+                const translate = svg.createSVGTransform();
+                translate.setTranslate(0, 0);
+
+                this.elementSelected.transform.baseVal.insertItemBefore(
+                    translate,
+                    0,
+                );
+            }
+
+            this.transform = transforms.getItem(0);
+            this.offset.x -= this.transform.matrix.e;
+            this.offset.y -= this.transform.matrix.f;
+        }
+    }
+
+    drag(event: MouseEvent) {
+        const target = event.target as SVGRectElement;
+        if (this.elementSelected !== null && this.mouseClicked === true) {
+            event.preventDefault();
+            const coord = this.getMousePosition(event);
+
+            if (this.transform !== undefined) {
+                let dx = coord.x - this.offset.x;
+                let dy = coord.y - this.offset.y;
+
+                // if (target.classList.contains('confine')) {
+                //     if (dx < this.minX) {
+                //         dx = this.minX;
+                //     } else if (dx > this.maxX) {
+                //         dx = this.maxX;
+                //     }
+
+                //     if (dy < this.minY) {
+                //         dy = this.minY;
+                //     } else if (dy > this.maxY) {
+                //         dy = this.maxY;
+                //     }
+                // }
+
+                this._positionForActivitiesService.updateElementPosition(
+                    this.transition.id,
+                    'transition',
+                    dx,
+                    dy,
+                );
+            }
+        }
+    }
+
+    endDrag(event: MouseEvent, pltransitionace: Transition) {
+        this.elementSelected = null;
+        if (this.mouseClicked) {
+            this._positionForActivitiesService.updateEndPositionOfElement(
+                this.transition.id,
+                'transition',
+                this.transition.x,
+                this.transition.y,
+            );
+            this.mouseClicked = false;
+        }
+    }
+
+    private getMousePosition(event: MouseEvent) {
+        const svg: SVGSVGElement = document.getElementsByTagName(
+            'svg',
+        )[0] as SVGSVGElement;
+        var CTM = svg.getScreenCTM();
+
+        if (!CTM) {
+            throw new Error('CTM is null');
+        }
+
+        return {
+            x: (event.clientX - CTM.e) / CTM.a,
+            y: (event.clientY - CTM.f) / CTM.d,
+        };
+    }
 }

--- a/src/app/components/drawing-area/components/drawing-transition.component.ts
+++ b/src/app/components/drawing-area/components/drawing-transition.component.ts
@@ -65,6 +65,18 @@ export class DrawingTransitionComponent {
     dx: number = 0;
     dy: number = 0;
 
+    bbox: any;
+
+    boundaryX1: number = 0;
+    boundaryX2: number = 0;
+    boundaryY1: number = 0;
+    boundaryY2: number = 0;
+
+    minX: number = 0;
+    maxX: number = 0;
+    minY: number = 0;
+    maxY: number = 0;
+
     startDrag(event: MouseEvent) {
         const svg: SVGSVGElement = document.getElementsByTagName(
             'svg',
@@ -72,11 +84,21 @@ export class DrawingTransitionComponent {
         const target = event.target as SVGRectElement;
         this.mouseClicked = true;
 
+        this.setBoundary(svg);
+
         if (target.classList.contains('draggable')) {
             this.offset = this.getMousePosition(event);
             this.elementSelected = target;
 
             const transforms = this.elementSelected.transform.baseVal;
+
+            if (target.classList.contains('confine')) {
+                this.bbox = target.getBBox();
+                this.minX = this.boundaryX1 - this.bbox.x;
+                this.maxX = this.boundaryX2 - this.bbox.x - this.bbox.width;
+                this.minY = this.boundaryY1 - this.bbox.y;
+                this.maxY = this.boundaryY2 - this.bbox.y - this.bbox.height;
+            }
 
             if (
                 transforms.length === 0 ||
@@ -108,19 +130,19 @@ export class DrawingTransitionComponent {
                 this.dx = coord.x - this.offset.x;
                 this.dy = coord.y - this.offset.y;
 
-                // if (target.classList.contains('confine')) {
-                //     if (dx < this.minX) {
-                //         dx = this.minX;
-                //     } else if (dx > this.maxX) {
-                //         dx = this.maxX;
-                //     }
+                if (target.classList.contains('confine')) {
+                    if (this.dx < this.minX) {
+                        this.dx = this.minX;
+                    } else if (this.dx > this.maxX) {
+                        this.dx = this.maxX;
+                    }
 
-                //     if (dy < this.minY) {
-                //         dy = this.minY;
-                //     } else if (dy > this.maxY) {
-                //         dy = this.maxY;
-                //     }
-                // }
+                    if (this.dy < this.minY) {
+                        this.dy = this.minY;
+                    } else if (this.dy > this.maxY) {
+                        this.dy = this.maxY;
+                    }
+                }
 
                 this._positionForActivitiesService.updateElementPosition(
                     this.transition.id,
@@ -161,5 +183,24 @@ export class DrawingTransitionComponent {
             x: (event.clientX - CTM.e) / CTM.a,
             y: (event.clientY - CTM.f) / CTM.d,
         };
+    }
+
+    private setBoundary(svg: SVGSVGElement): void {
+        const drawingArea = document.getElementById('drawingArea');
+        if (drawingArea && svg) {
+            const drawingAreaBox = drawingArea.getBoundingClientRect();
+            const svgBox = svg.getBoundingClientRect();
+
+            this.boundaryX2 = drawingAreaBox.width;
+            this.boundaryY2 = drawingAreaBox.height;
+
+            if (svgBox.width > drawingAreaBox.width) {
+                this.boundaryX2 = svgBox.width;
+            }
+
+            if (svgBox.height > drawingAreaBox.height) {
+                this.boundaryY2 = svgBox.height;
+            }
+        }
     }
 }

--- a/src/app/services/position-for-activities.service.ts
+++ b/src/app/services/position-for-activities.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { Activity, Arc, Box } from '../components/drawing-area';
-import { BoxNode } from '../classes/graph';
+import { Box } from '../components/drawing-area';
 
 @Injectable({
     providedIn: 'root',
@@ -43,22 +42,7 @@ export class PositionForActivitiesService {
         return this._boxDimensions$.asObservable();
     }
 
-    // //--------- Subscription 4 ---------
-    // private readonly _movingPlaceInGraph$: BehaviorSubject<
-    //     [place: string, x: number, y: number]
-    // > = new BehaviorSubject<[placeId: string, x: number, y: number]>([
-    //     '',
-    //     0,
-    //     0,
-    // ]);
-
-    // get movingPlaceInGraph$(): Observable<
-    //     [placeId: string, x: number, y: number]
-    // > {
-    //     return this._movingPlaceInGraph$.asObservable();
-    // }
-
-    //--------- Subscription 5 ---------
+    //--------- Subscription 4 ---------
     private readonly _updateEndPositionOfElement$: BehaviorSubject<
         [
             elementId: string,
@@ -92,7 +76,7 @@ export class PositionForActivitiesService {
         return this._updateEndPositionOfElement$.asObservable();
     }
 
-    //--------- Subscription 6 ---------
+    //--------- Subscription 5 ---------
     private readonly _movingElementInGraph$: BehaviorSubject<
         [elementId: string, elementType: string, x: number, y: number]
     > = new BehaviorSubject<
@@ -120,14 +104,6 @@ export class PositionForActivitiesService {
             yTranslate,
         ]);
     }
-
-    // updatePlacePosition(
-    //     placeId: string,
-    //     xTranslate: number,
-    //     yTranslate: number,
-    // ) {
-    //     this._movingPlaceInGraph$.next([placeId, xTranslate, yTranslate]);
-    // }
 
     public updateElementPosition(
         elementId: string,
@@ -169,10 +145,6 @@ export class PositionForActivitiesService {
             yTranslate,
         ]);
     }
-
-    // updateCoordinatesOfArcs(placeId: string, newX: number, newY: number) {
-    //     this._updateArcCoordinates$.next([placeId, newX, newY]);
-    // }
 
     passBoxObjects(box: Box[]): void {
         this._boxDimensions$.next(box);

--- a/src/app/services/position-for-activities.service.ts
+++ b/src/app/services/position-for-activities.service.ts
@@ -23,16 +23,16 @@ export class PositionForActivitiesService {
     }
 
     //--------- Subscription 2 ---------
-    private readonly _updateArcCoordinates$: BehaviorSubject<
+    private readonly _updateBoxArcCoordinates$: BehaviorSubject<
         [activityId: string, dfgId: string, x: number, y: number]
     > = new BehaviorSubject<
         [activityId: string, dfgId: string, x: number, y: number]
     >(['', '', 0, 0]);
 
-    get updateArcCoordinates$(): Observable<
+    get updateBoxArcCoordinates$(): Observable<
         [activityId: string, dfgId: string, x: number, y: number]
     > {
-        return this._updateArcCoordinates$.asObservable();
+        return this._updateBoxArcCoordinates$.asObservable();
     }
 
     //--------- Subscription 3 ---------
@@ -43,7 +43,50 @@ export class PositionForActivitiesService {
         return this._boxDimensions$.asObservable();
     }
 
-    updatePosition(
+    // //--------- Subscription 4 ---------
+    // private readonly _movingPlaceInGraph$: BehaviorSubject<
+    //     [place: string, x: number, y: number]
+    // > = new BehaviorSubject<[placeId: string, x: number, y: number]>([
+    //     '',
+    //     0,
+    //     0,
+    // ]);
+
+    // get movingPlaceInGraph$(): Observable<
+    //     [placeId: string, x: number, y: number]
+    // > {
+    //     return this._movingPlaceInGraph$.asObservable();
+    // }
+
+    //--------- Subscription 5 ---------
+    private readonly _updateEndPositionOfElement$: BehaviorSubject<
+        [elementId: string, elementType: string, x: number, y: number]
+    > = new BehaviorSubject<
+        [elementId: string, elementType: string, x: number, y: number]
+    >(['', '', 0, 0]);
+
+    get updateEndPositionOfElement$(): Observable<
+        [elementId: string, elementType: string, x: number, y: number]
+    > {
+        return this._updateEndPositionOfElement$.asObservable();
+    }
+
+    //--------- Subscription 6 ---------
+    private readonly _movingElementInGraph$: BehaviorSubject<
+        [elementId: string, elementType: string, x: number, y: number]
+    > = new BehaviorSubject<
+        [elementId: string, elementType: string, x: number, y: number]
+    >(['', '', 0, 0]);
+
+    get movingElementInGraph$(): Observable<
+        [elementId: string, elementType: string, x: number, y: number]
+    > {
+        return this._movingElementInGraph$.asObservable();
+    }
+
+    //--------- MAIN ---------
+
+    updateActivityPosition(
         activityId: string,
         dfgId: string,
         xTranslate: number,
@@ -57,14 +100,54 @@ export class PositionForActivitiesService {
         ]);
     }
 
-    updateCoordinatesOfArcs(
+    // updatePlacePosition(
+    //     placeId: string,
+    //     xTranslate: number,
+    //     yTranslate: number,
+    // ) {
+    //     this._movingPlaceInGraph$.next([placeId, xTranslate, yTranslate]);
+    // }
+
+    updateElementPosition(
+        elementId: string,
+        elementType: string,
+        xTranslate: number,
+        yTranslate: number,
+    ) {
+        this._movingElementInGraph$.next([
+            elementId,
+            elementType,
+            xTranslate,
+            yTranslate,
+        ]);
+    }
+
+    updateCoordinatesOfBoxArcs(
         activityId: string,
         dfgId: string,
         newX: number,
         newY: number,
     ): void {
-        this._updateArcCoordinates$.next([activityId, dfgId, newX, newY]);
+        this._updateBoxArcCoordinates$.next([activityId, dfgId, newX, newY]);
     }
+
+    updateEndPositionOfElement(
+        elementId: string,
+        elementType: string,
+        newX: number,
+        newY: number,
+    ) {
+        this._updateEndPositionOfElement$.next([
+            elementId,
+            elementType,
+            newX,
+            newY,
+        ]);
+    }
+
+    // updateCoordinatesOfArcs(placeId: string, newX: number, newY: number) {
+    //     this._updateArcCoordinates$.next([placeId, newX, newY]);
+    // }
 
     passBoxObjects(box: Box[]): void {
         this._boxDimensions$.next(box);

--- a/src/app/services/position-for-activities.service.ts
+++ b/src/app/services/position-for-activities.service.ts
@@ -60,13 +60,34 @@ export class PositionForActivitiesService {
 
     //--------- Subscription 5 ---------
     private readonly _updateEndPositionOfElement$: BehaviorSubject<
-        [elementId: string, elementType: string, x: number, y: number]
+        [
+            elementId: string,
+            elementType: string,
+            x: number,
+            y: number,
+            xTranslate: number,
+            yTranslate: number,
+        ]
     > = new BehaviorSubject<
-        [elementId: string, elementType: string, x: number, y: number]
-    >(['', '', 0, 0]);
+        [
+            elementId: string,
+            elementType: string,
+            x: number,
+            y: number,
+            xTranslate: number,
+            yTranslate: number,
+        ]
+    >(['', '', 0, 0, 0, 0]);
 
     get updateEndPositionOfElement$(): Observable<
-        [elementId: string, elementType: string, x: number, y: number]
+        [
+            elementId: string,
+            elementType: string,
+            x: number,
+            y: number,
+            xTranslate: number,
+            yTranslate: number,
+        ]
     > {
         return this._updateEndPositionOfElement$.asObservable();
     }
@@ -86,7 +107,7 @@ export class PositionForActivitiesService {
 
     //--------- MAIN ---------
 
-    updateActivityPosition(
+    public updateActivityPosition(
         activityId: string,
         dfgId: string,
         xTranslate: number,
@@ -108,7 +129,7 @@ export class PositionForActivitiesService {
     //     this._movingPlaceInGraph$.next([placeId, xTranslate, yTranslate]);
     // }
 
-    updateElementPosition(
+    public updateElementPosition(
         elementId: string,
         elementType: string,
         xTranslate: number,
@@ -122,7 +143,7 @@ export class PositionForActivitiesService {
         ]);
     }
 
-    updateCoordinatesOfBoxArcs(
+    public updateCoordinatesOfBoxArcs(
         activityId: string,
         dfgId: string,
         newX: number,
@@ -131,17 +152,21 @@ export class PositionForActivitiesService {
         this._updateBoxArcCoordinates$.next([activityId, dfgId, newX, newY]);
     }
 
-    updateEndPositionOfElement(
+    public updateEndPositionOfElement(
         elementId: string,
         elementType: string,
         newX: number,
         newY: number,
+        xTranslate: number,
+        yTranslate: number,
     ) {
         this._updateEndPositionOfElement$.next([
             elementId,
             elementType,
             newX,
             newY,
+            xTranslate,
+            yTranslate,
         ]);
     }
 


### PR DESCRIPTION
Alle Elemente des Petri-Netzes lassen sich nun verschieben. Sie können nicht nach unten und oben über die Drawing Area hinaus verschoben werden. Nach rechts und unten gibt es keine Begrenzung, da dann ein Scroll-Balken entsteht und die Elemente weiterhin sichtbar sind.