### PR TITLE
SCRUM-111: change position of legend menu

### DIFF
--- a/src/app/components/context-menu/context-menu.component.css
+++ b/src/app/components/context-menu/context-menu.component.css
@@ -133,8 +133,10 @@
             .legend-menu {
                 display: flex !important;
                 position: absolute;
-                top: 0;
+                top: auto;
                 left: 100%;
+                right: unset;
+                bottom: 0px;
                 background-color: #f2e0e9;
                 border: 1px dashed grey;
                 border-radius: 4%;
@@ -178,11 +180,22 @@
         }
     }
 
+    .legend-menu-wrapper {
+        &:not(.disabled):hover {
+            .legend-menu {
+                left: unset;
+                right: 100%;
+            }
+        }
+    }
+
     .sub-sub-menu-wrapper {
         &:not(.disabled):hover {
             .sub-sub-menu {
                 left: unset;
                 right: 100%;
+                top: 0;
+                position: absolute;
             }
         }
     }

--- a/src/app/components/context-menu/context-menu.component.css
+++ b/src/app/components/context-menu/context-menu.component.css
@@ -57,6 +57,7 @@
         }
         div {
             flex-grow: 1;
+            padding: 10px 0px 10px 0px;
         }
     }
 
@@ -140,12 +141,6 @@
                 background-color: #f2e0e9;
                 border: 1px dashed grey;
                 border-radius: 4%;
-
-                .hr-legend-menu {
-                    height: 0px;
-                    border-top: 1px dotted #ff007798;
-                    margin-top: 15px;
-                }
             }
         }
     }

--- a/src/app/components/context-menu/context-menu.component.html
+++ b/src/app/components/context-menu/context-menu.component.html
@@ -258,15 +258,17 @@
             <div class="legend-menu-line">
                 <h1>The Arc Feedback</h1>
             </div>
+            <div><br /></div>
             <div class="legend-menu-line">
                 <div>
-                    Activating this feature marks arcs in different colors,
+                    Activating this feature marks arcs <br />
+                    in different colors,
                     <br />
                     if the selected cut type is possible. <br />
                     Otherwise, they are marked in red only.
                 </div>
             </div>
-            <div class="hr-legend-menu"></div>
+            <div><br /></div>
             <div class="legend-menu-line">
                 <mat-icon class="green">call_made</mat-icon>
                 <div class="green">green arcs = definitely right</div>


### PR DESCRIPTION
Position der Legende generell etwas nach oben verlagert.

Ist man zu weit rechts mit dem Kontextmenü wird die Legende, wie der Rest auch nach links verlagert.